### PR TITLE
Surface RateLimitEvent and MirrorErrorMessage in Claude Agent SDK instrumentation

### DIFF
--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -18,6 +18,13 @@ from claude_agent_sdk import (
     UserMessage,
 )
 from claude_agent_sdk.types import HookContext, SyncHookJSONOutput
+
+# Optional message types — resolved at module load from the installed SDK so
+# older versions that lack them still import cleanly. Using getattr avoids
+# a redundant try/except on a module we've already imported above.
+RateLimitEvent = getattr(claude_agent_sdk, 'RateLimitEvent', None)
+MirrorErrorMessage = getattr(claude_agent_sdk, 'MirrorErrorMessage', None)
+
 from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
@@ -27,6 +34,14 @@ from logfire._internal.integrations.llm_providers.semconv import (
     OPERATION_NAME,
     OUTPUT_MESSAGES,
     PROVIDER_NAME,
+    RATE_LIMIT_OVERAGE_DISABLED_REASON,
+    RATE_LIMIT_OVERAGE_RESETS_AT,
+    RATE_LIMIT_OVERAGE_STATUS,
+    RATE_LIMIT_RAW,
+    RATE_LIMIT_RESETS_AT,
+    RATE_LIMIT_STATUS,
+    RATE_LIMIT_TYPE,
+    RATE_LIMIT_UTILIZATION,
     REQUEST_MODEL,
     RESPONSE_MODEL,
     SYSTEM,
@@ -46,6 +61,11 @@ from logfire._internal.integrations.llm_providers.semconv import (
 from logfire._internal.utils import handle_internal_errors
 
 if TYPE_CHECKING:
+    # String forward refs for the SDK types that may be absent at runtime on
+    # older SDK versions (see getattr above).
+    from claude_agent_sdk import MirrorErrorMessage as _MirrorErrorMessage
+    from claude_agent_sdk import RateLimitEvent as _RateLimitEvent
+
     from logfire._internal.main import Logfire, LogfireSpan
 
 
@@ -365,11 +385,15 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                             state.handle_assistant_message(msg)
                         elif isinstance(msg, UserMessage):
                             state.handle_user_message()
-                        elif isinstance(msg, ResultMessage):  # pragma: no branch
+                        elif isinstance(msg, ResultMessage):
                             _record_result(root_span, msg)
                             if state.model:  # pragma: no branch
                                 root_span.set_attribute(REQUEST_MODEL, state.model)
                                 root_span.set_attribute(RESPONSE_MODEL, state.model)
+                        elif RateLimitEvent is not None and isinstance(msg, RateLimitEvent):
+                            _record_rate_limit_event(logfire_claude, root_span, msg)
+                        elif MirrorErrorMessage is not None and isinstance(msg, MirrorErrorMessage):
+                            _record_mirror_error(logfire_claude, msg)
 
                     yield msg
             finally:
@@ -529,6 +553,70 @@ class _ConversationState:
         for span in self.active_tool_spans.values():
             span._end()  # pyright: ignore[reportPrivateUsage]
         self.active_tool_spans.clear()
+
+
+def _record_rate_limit_event(
+    logfire_instance: Logfire, root_span: LogfireSpan, msg: _RateLimitEvent
+) -> None:
+    """Record a RateLimitEvent as a level-appropriate log under the root span.
+
+    The SDK emits these whenever the CLI reports a rate-limit state transition
+    (``allowed`` → ``allowed_warning`` → ``rejected``), plus overage state. We
+    surface them as logfire events so alerting can key off them.
+    """
+    info = getattr(msg, 'rate_limit_info', None)
+    status = getattr(info, 'status', None)
+    attrs: dict[str, Any] = {RATE_LIMIT_STATUS: status}
+    # Map SDK field → semconv constant. Only emit set values.
+    field_map: tuple[tuple[str, str], ...] = (
+        ('resets_at', RATE_LIMIT_RESETS_AT),
+        ('rate_limit_type', RATE_LIMIT_TYPE),
+        ('utilization', RATE_LIMIT_UTILIZATION),
+        ('overage_status', RATE_LIMIT_OVERAGE_STATUS),
+        ('overage_resets_at', RATE_LIMIT_OVERAGE_RESETS_AT),
+        ('overage_disabled_reason', RATE_LIMIT_OVERAGE_DISABLED_REASON),
+        ('raw', RATE_LIMIT_RAW),
+    )
+    for sdk_field, attr_name in field_map:
+        val = getattr(info, sdk_field, None)
+        if val:
+            attrs[attr_name] = val
+    conv_id = getattr(msg, 'session_id', None)
+    if conv_id is not None:
+        attrs[CONVERSATION_ID] = conv_id
+
+    if status == 'rejected':
+        attrs[ERROR_TYPE] = 'RateLimitRejected'
+        root_span.set_level('error')
+        log = logfire_instance.error
+    elif status == 'allowed_warning':
+        log = logfire_instance.warn
+    else:
+        log = logfire_instance.info
+    log('rate_limit {status}', status=status, **attrs)
+
+
+def _record_mirror_error(logfire_instance: Logfire, msg: _MirrorErrorMessage) -> None:
+    """Record a MirrorErrorMessage as an error-level log under the root span.
+
+    Mirror errors are non-fatal (the local transcript is still durable) but
+    indicate drift from an external SessionStore — worth surfacing. The raw
+    SessionKey dict is unpacked into individual attributes (``session_id`` →
+    ``gen_ai.conversation.id``, plus ``project_key`` / ``subpath``) rather
+    than serialized whole, because logfire's default scrubber matches the
+    substring ``session`` in attribute values and would redact the whole blob.
+    """
+    error = getattr(msg, 'error', '') or ''
+    attrs: dict[str, Any] = {ERROR_TYPE: 'MirrorError'}
+    key = getattr(msg, 'key', None)
+    if isinstance(key, dict):
+        if (sid := key.get('session_id')) is not None:
+            attrs[CONVERSATION_ID] = sid
+        if (pk := key.get('project_key')) is not None:
+            attrs['mirror.project_key'] = pk
+        if (sp := key.get('subpath')) is not None:
+            attrs['mirror.subpath'] = sp
+    logfire_instance.error('mirror store error: {error}', error=error, **attrs)
 
 
 def _record_result(span: LogfireSpan, msg: ResultMessage) -> None:

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -91,6 +91,17 @@ CONVERSATION_ID = 'gen_ai.conversation.id'
 # Error
 ERROR_TYPE = 'error.type'
 
+# Rate-limit (custom extension; not yet in upstream OTel gen-ai semconv).
+# Surfaced by the Claude Agent SDK as RateLimitEvent messages.
+RATE_LIMIT_STATUS = 'gen_ai.rate_limit.status'
+RATE_LIMIT_TYPE = 'gen_ai.rate_limit.type'
+RATE_LIMIT_UTILIZATION = 'gen_ai.rate_limit.utilization'
+RATE_LIMIT_RESETS_AT = 'gen_ai.rate_limit.resets_at'
+RATE_LIMIT_OVERAGE_STATUS = 'gen_ai.rate_limit.overage.status'
+RATE_LIMIT_OVERAGE_RESETS_AT = 'gen_ai.rate_limit.overage.resets_at'
+RATE_LIMIT_OVERAGE_DISABLED_REASON = 'gen_ai.rate_limit.overage.disabled_reason'
+RATE_LIMIT_RAW = 'gen_ai.rate_limit.raw'
+
 # Type definitions for message parts and messages
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,7 @@ dev = [
     "pytest-examples>=0.0.18",
     "pytest-timeout>=2.4.0",
     "pytest-asyncio>=0.24.0",
-    "claude-agent-sdk>=0 ; python_full_version >= '3.10'",
+    "claude-agent-sdk>=0.1.62 ; python_full_version >= '3.10'",
 ]
 docs = [
     "black>=23.12.0",
@@ -235,6 +235,8 @@ pydantic-graph = false
 pydantic-evals = false
 pydantic = false
 pydantic-core = false
+# Dev-only dep; upgrade freely so the version pin (>= 0.1.62) can resolve.
+claude-agent-sdk = false
 
 [tool.uv.workspace]
 members = ["logfire-api"]

--- a/tests/otel_integrations/cassettes/test_claude_agent_sdk/ratelimit_mirror_conversation.json
+++ b/tests/otel_integrations/cassettes/test_claude_agent_sdk/ratelimit_mirror_conversation.json
@@ -1,0 +1,436 @@
+{
+  "metadata": {
+    "cli_version": "1.0.100"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_632f6b22",
+        "request": {
+          "subtype": "initialize",
+          "hooks": {
+            "PreToolUse": [
+              {
+                "matcher": null,
+                "hookCallbackIds": [
+                  "hook_0"
+                ]
+              }
+            ],
+            "PostToolUse": [
+              {
+                "matcher": null,
+                "hookCallbackIds": [
+                  "hook_1"
+                ]
+              }
+            ],
+            "PostToolUseFailure": [
+              {
+                "matcher": null,
+                "hookCallbackIds": [
+                  "hook_2"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_632f6b22",
+          "response": {
+            "commands": [
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, use Config tool. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "simplify",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "argumentHint": "[interval] <prompt>"
+              },
+              {
+                "name": "schedule",
+                "description": "Create, update, list, or run scheduled remote agents (triggers) that execute on a cron schedule. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "claude-api",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "compact",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "cost",
+                "description": "Show the total cost and duration of the current session",
+                "argumentHint": ""
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "pr-comments",
+                "description": "Get comments from a GitHub pull request",
+                "argumentHint": ""
+              },
+              {
+                "name": "release-notes",
+                "description": "View release notes",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": ""
+              },
+              {
+                "name": "review",
+                "description": "Review a pull request",
+                "argumentHint": ""
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              },
+              {
+                "name": "Explore",
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku"
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs."
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet[1m]",
+                "displayName": "Sonnet (1M context)",
+                "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 4.6 with 1M context \u00b7 Most capable for complex work",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              }
+            ],
+            "account": {
+              "tokenSource": "claude.ai",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 69806
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "What is 2+2?"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/Users/alex/work/logfire",
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "tools": [
+          "Task",
+          "AskUserQuestion",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "Edit",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "ExitPlanMode",
+          "ExitWorktree",
+          "Glob",
+          "Grep",
+          "NotebookEdit",
+          "Read",
+          "RemoteTrigger",
+          "Skill",
+          "TaskOutput",
+          "TaskStop",
+          "TodoWrite",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Write"
+        ],
+        "mcp_servers": [
+          {
+            "name": "claude.ai Gmail",
+            "status": "needs-auth"
+          },
+          {
+            "name": "claude.ai Google Calendar",
+            "status": "needs-auth"
+          }
+        ],
+        "model": "claude-sonnet-4-6",
+        "permissionMode": "default",
+        "slash_commands": [
+          "update-config",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "schedule",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "reload-plugins",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.84",
+        "output_style": "default",
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "skills": [
+          "update-config",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "schedule",
+          "claude-api"
+        ],
+        "plugins": [],
+        "uuid": "04efccad-5aa3-4768-9679-daf6f99c3dd7",
+        "fast_mode_state": "off"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "rate_limit_event",
+        "uuid": "test-rl-uuid-0001",
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "rate_limit_info": {
+          "status": "allowed_warning",
+          "resetsAt": 1800000000,
+          "rateLimitType": "five_hour",
+          "utilization": 0.87
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "mirror_error",
+        "key": {
+          "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be"
+        },
+        "error": "store append timed out"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-sonnet-4-6",
+          "id": "msg_01BxK8UH2LyuFLVXSPamqHam",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "4"
+            }
+          ],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 2175,
+            "cache_read_input_tokens": 7166,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 2175,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 1,
+            "service_tier": "standard",
+            "inference_geo": "global"
+          },
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "uuid": "ce1101bc-27c6-41b1-ae16-5edf06b0927c"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "duration_ms": 2263,
+        "duration_api_ms": 2257,
+        "num_turns": 1,
+        "result": "4",
+        "stop_reason": "end_turn",
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "total_cost_usd": 0.01039005,
+        "usage": {
+          "input_tokens": 3,
+          "cache_creation_input_tokens": 2175,
+          "cache_read_input_tokens": 7166,
+          "output_tokens": 5,
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 2175
+          },
+          "inference_geo": "",
+          "iterations": [],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-sonnet-4-6": {
+            "inputTokens": 3,
+            "outputTokens": 5,
+            "cacheReadInputTokens": 7166,
+            "cacheCreationInputTokens": 2175,
+            "webSearchRequests": 0,
+            "costUSD": 0.01039005,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000
+          }
+        },
+        "permission_denials": [],
+        "fast_mode_state": "off",
+        "uuid": "2e5b4c65-96d5-4474-a425-77830ab6f23a"
+      }
+    }
+  ]
+}

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -19,6 +19,7 @@ import shutil
 import stat
 from contextlib import suppress
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -45,6 +46,8 @@ from logfire._internal.integrations.claude_agent_sdk import (
     _ConversationState,
     _extract_usage,
     _inject_tracing_hooks,
+    _record_mirror_error,
+    _record_rate_limit_event,
     _set_state,
     post_tool_use_failure_hook,
     post_tool_use_hook,
@@ -999,3 +1002,248 @@ uv.lock\
             },
         ]
     )
+
+
+@pytest.mark.anyio
+async def test_ratelimit_and_mirror_error_cassette(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, exporter: TestExporter
+) -> None:
+    """RateLimitEvent and MirrorErrorMessage in the stream produce log spans.
+
+    The cassette is basic_conversation.json with two extra ``recv`` entries
+    spliced in right after ``system/init``: a ``rate_limit_event`` with
+    status ``allowed_warning`` and a ``system/mirror_error``. This exercises
+    the branches added for logfire issue #2.
+    """
+    record = request.config.getoption('--record-claude-cassettes', default=False)
+    # Recording is not meaningful for this cassette — mirror_error is
+    # SDK-synthesized (not emitted by the CLI) and rate_limit_event requires
+    # a real rate-limit transition. The cassette is hand-assembled; skip the
+    # record path so CI never tries to overwrite it.
+    if record:  # pragma: no cover
+        pytest.skip('ratelimit_mirror_conversation.json is hand-assembled, not recorded')
+
+    import claude_agent_sdk as _sdk
+
+    if not hasattr(_sdk, 'RateLimitEvent') or not hasattr(_sdk, 'MirrorErrorMessage'):
+        pytest.skip('SDK version lacks RateLimitEvent / MirrorErrorMessage — needs claude-agent-sdk >= 0.1.62')
+
+    client = _make_client('ratelimit_mirror_conversation.json', monkeypatch=monkeypatch)
+    try:
+        await client.connect()
+        await client.query('What is 2+2?')
+        collected = [msg async for msg in client.receive_response()]
+    finally:
+        await _close_sdk_streams(client)
+        await client.disconnect()
+
+    # SDK itself should have yielded both messages through to the caller.
+    assert any(isinstance(m, _sdk.RateLimitEvent) for m in collected), 'SDK did not yield RateLimitEvent'
+    assert any(isinstance(m, _sdk.MirrorErrorMessage) for m in collected), 'SDK did not yield MirrorErrorMessage'
+
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'rate_limit {status}',
+                'context': {'trace_id': 1, 'span_id': 5, 'is_remote': False},
+                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'start_time': 3000000000,
+                'end_time': 3000000000,
+                'attributes': {
+                    'logfire.span_type': 'log',
+                    'logfire.level_num': 13,
+                    'logfire.msg_template': 'rate_limit {status}',
+                    'logfire.msg': 'rate_limit allowed_warning',
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
+                    'code.lineno': 123,
+                    'status': 'allowed_warning',
+                    'gen_ai.rate_limit.status': 'allowed_warning',
+                    'gen_ai.rate_limit.resets_at': 1800000000,
+                    'gen_ai.rate_limit.type': 'five_hour',
+                    'gen_ai.rate_limit.utilization': 0.87,
+                    'gen_ai.rate_limit.raw': {
+                        'status': 'allowed_warning',
+                        'resetsAt': 1800000000,
+                        'rateLimitType': 'five_hour',
+                        'utilization': 0.87,
+                    },
+                    'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {
+                            'status': {},
+                            'gen_ai.rate_limit.status': {},
+                            'gen_ai.rate_limit.resets_at': {},
+                            'gen_ai.rate_limit.type': {},
+                            'gen_ai.rate_limit.utilization': {},
+                            'gen_ai.rate_limit.raw': {'type': 'object'},
+                            'gen_ai.conversation.id': {},
+                        },
+                    },
+                },
+            },
+            {
+                'name': 'mirror store error: {error}',
+                'context': {'trace_id': 1, 'span_id': 6, 'is_remote': False},
+                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'start_time': 4000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'logfire.span_type': 'log',
+                    'logfire.level_num': 17,
+                    'logfire.msg_template': 'mirror store error: {error}',
+                    'logfire.msg': 'mirror store error: store append timed out',
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
+                    'code.lineno': 123,
+                    'error': 'store append timed out',
+                    'error.type': 'MirrorError',
+                    'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {'error': {}, 'error.type': {}, 'gen_ai.conversation.id': {}},
+                    },
+                },
+            },
+            {
+                'name': 'chat claude-sonnet-4-6',
+                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
+                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'start_time': 2000000000,
+                'end_time': 5000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
+                    'code.lineno': 123,
+                    'gen_ai.operation.name': 'chat',
+                    'gen_ai.provider.name': 'anthropic',
+                    'gen_ai.system': 'anthropic',
+                    'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
+                    'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
+                    'logfire.msg_template': 'chat',
+                    'logfire.span_type': 'span',
+                    'gen_ai.output.messages': [{'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]}],
+                    'gen_ai.request.model': 'claude-sonnet-4-6',
+                    'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'logfire.msg': 'chat claude-sonnet-4-6',
+                    'gen_ai.usage.partial.input_tokens': 9344,
+                    'gen_ai.usage.partial.output_tokens': 1,
+                    'gen_ai.usage.partial.cache_read.input_tokens': 7166,
+                    'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {
+                            'gen_ai.operation.name': {},
+                            'gen_ai.provider.name': {},
+                            'gen_ai.system': {},
+                            'gen_ai.input.messages': {'type': 'array'},
+                            'gen_ai.system_instructions': {'type': 'array'},
+                            'gen_ai.output.messages': {'type': 'array'},
+                            'gen_ai.request.model': {},
+                            'gen_ai.response.model': {},
+                            'gen_ai.usage.partial.input_tokens': {},
+                            'gen_ai.usage.partial.output_tokens': {},
+                            'gen_ai.usage.partial.cache_read.input_tokens': {},
+                            'gen_ai.usage.partial.cache_creation.input_tokens': {},
+                        },
+                    },
+                },
+            },
+            {
+                'name': 'invoke_agent',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 6000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
+                    'code.lineno': 123,
+                    'gen_ai.operation.name': 'invoke_agent',
+                    'gen_ai.provider.name': 'anthropic',
+                    'gen_ai.system': 'anthropic',
+                    'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
+                    'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
+                    'logfire.msg_template': 'invoke_agent',
+                    'logfire.msg': 'invoke_agent',
+                    'logfire.span_type': 'span',
+                    'gen_ai.usage.input_tokens': 9344,
+                    'gen_ai.usage.output_tokens': 5,
+                    'gen_ai.usage.cache_read.input_tokens': 7166,
+                    'gen_ai.usage.cache_creation.input_tokens': 2175,
+                    'operation.cost': 0.01039005,
+                    'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
+                    'num_turns': 1,
+                    'duration_ms': 2263,
+                    'gen_ai.request.model': 'claude-sonnet-4-6',
+                    'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {
+                            'gen_ai.operation.name': {},
+                            'gen_ai.provider.name': {},
+                            'gen_ai.system': {},
+                            'gen_ai.input.messages': {'type': 'array'},
+                            'gen_ai.system_instructions': {'type': 'array'},
+                            'gen_ai.usage.input_tokens': {},
+                            'gen_ai.usage.output_tokens': {},
+                            'gen_ai.usage.cache_read.input_tokens': {},
+                            'gen_ai.usage.cache_creation.input_tokens': {},
+                            'operation.cost': {},
+                            'gen_ai.conversation.id': {},
+                            'num_turns': {},
+                            'duration_ms': {},
+                            'gen_ai.request.model': {},
+                            'gen_ai.response.model': {},
+                        },
+                    },
+                },
+            },
+        ]
+    )
+
+
+@pytest.mark.anyio
+async def test_rate_limit_rejected_sets_error_level(exporter: TestExporter) -> None:
+    """A ``rate_limit_event`` with status 'rejected' escalates the root span."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        msg = SimpleNamespace(
+            rate_limit_info=SimpleNamespace(
+                status='rejected',
+                resets_at=1800000000,
+                rate_limit_type='five_hour',
+                utilization=1.0,
+                overage_status=None,
+                overage_resets_at=None,
+                overage_disabled_reason=None,
+            ),
+            session_id='sess-abc',
+        )
+        _record_rate_limit_event(logfire_instance, root, msg)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log_spans = [s for s in spans if s['name'] == 'rate_limit {status}']
+    assert len(log_spans) == 1
+    log = log_spans[0]
+    assert log['attributes']['logfire.level_num'] == 17  # error
+    assert log['attributes']['error.type'] == 'RateLimitRejected'
+
+    # Root span itself is escalated to error via set_level.
+    root_spans = [s for s in spans if s['name'] == 'invoke_agent']
+    assert len(root_spans) == 1
+    assert root_spans[0]['attributes']['logfire.level_num'] == 17
+
+
+@pytest.mark.anyio
+async def test_mirror_error_without_key(exporter: TestExporter) -> None:
+    """MirrorErrorMessage with key=None (not every mirror error has one)."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent'):
+        _record_mirror_error(logfire_instance, SimpleNamespace(error='oh no', key=None))
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    mirror = next(s for s in spans if s['name'] == 'mirror store error: {error}')
+    assert mirror['attributes']['error.type'] == 'MirrorError'
+    assert 'gen_ai.conversation.id' not in mirror['attributes']

--- a/uv.lock
+++ b/uv.lock
@@ -31,6 +31,7 @@ pydantic-ai-slim = false
 mkdocstrings-python = false
 pydantic-graph = false
 pydantic-evals = false
+claude-agent-sdk = false
 
 [manifest]
 members = [
@@ -967,20 +968,20 @@ wheels = [
 
 [[package]]
 name = "claude-agent-sdk"
-version = "0.1.59"
+version = "0.1.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", version = "4.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
     { name = "mcp", marker = "python_full_version >= '3.10'" },
     { name = "typing-extensions", marker = "python_full_version == '3.10.*'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/55/438f5ba33f90cc9cbf3b40f74fbedf6792332e8fe34838f4189e418a4090/claude_agent_sdk-0.1.59.tar.gz", hash = "sha256:061af12a783a3456abfd0def3602a01249b2eee1be783fb3e242392c0ebbd2e2", size = 122887, upload-time = "2026-04-13T22:07:09.576Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/74/ff47c188637e16a781afcc8419da487a4860ba6d8e4ad16ea29f40e99038/claude_agent_sdk-0.1.66.tar.gz", hash = "sha256:b8fb14198456f536f71733a4da84ec79c44d7f91b06ff34a4786087a1b043c48", size = 233308, upload-time = "2026-04-23T23:35:23.209Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/6d/1fdfbcce76d7b81e89b29ad11864a48779a880f828c2541df620686693dd/claude_agent_sdk-0.1.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b8734b5d630b75ad63b29a802fff40ba087adf463c1004dae65f7a5a912ab13a", size = 59629367, upload-time = "2026-04-13T22:07:14.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b4/c6/aa9c5b310851b74db82e0da73a836335af4ef6767982d93ac04df52ef0cb/claude_agent_sdk-0.1.59-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:b333c0685db3f6e035acd2c6efa6ae4c4d8b077fef99de829ddb2a37ca1d9183", size = 61444059, upload-time = "2026-04-13T22:07:20.677Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/47/4ba5eb8846fcb9ba544d777ff752ff20c10a508931199f9def3e724dcc8b/claude_agent_sdk-0.1.59-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:8ebe1f7e6dc18c5fae6483977ff16fcabe91cbb955f9c423c05a11f013db3957", size = 72938796, upload-time = "2026-04-13T22:07:27.147Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/df/366d8ffb3399426769a08b68bdb4bf4ccb0c8e742418a27c3d369cfab07a/claude_agent_sdk-0.1.59-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:cac6c42f3c554981597a3d023bc87fe5b4bc14da987d9ef30cc2596005c3bc12", size = 73057901, upload-time = "2026-04-13T22:07:35.372Z" },
-    { url = "https://files.pythonhosted.org/packages/27/5a/f7506588831eb664c45241745d2cd21bd095b0f432ef2fa1062b824c538a/claude_agent_sdk-0.1.59-py3-none-win_amd64.whl", hash = "sha256:92d8da9ea5f0b4a7492d074d612d54b5e6ce6800312992aa48b2bcaa6bf7bf5e", size = 75161150, upload-time = "2026-04-13T22:07:43.695Z" },
+    { url = "https://files.pythonhosted.org/packages/62/e0/a1f0e510b506dc3dd6da47eeaf1e750882d2ade11cda8f301a353290b671/claude_agent_sdk-0.1.66-py3-none-macosx_11_0_arm64.whl", hash = "sha256:18c35bdf52ba3c2a0a694fa3981484e5f5432e7c96cfbd76d70d73aef2a8b87e", size = 63218880, upload-time = "2026-04-23T23:35:27.679Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c1/f451c5168d98027665b2356b7baebbb898d5ab3bded41788e5c823790ba7/claude_agent_sdk-0.1.66-py3-none-macosx_11_0_x86_64.whl", hash = "sha256:c8281b0af9733bdcd4672dcc334006af6e5bf83098be38e66222feb9e32a0f41", size = 65184888, upload-time = "2026-04-23T23:35:31.932Z" },
+    { url = "https://files.pythonhosted.org/packages/59/40/49b81d04cc579e207676626eb777d7c99e566777fd696643db2c550c86ee/claude_agent_sdk-0.1.66-py3-none-manylinux_2_17_aarch64.whl", hash = "sha256:32536a6033dd6ea0fd63191389e77b4208f7ebafea8f8cb4d0befeff52e60a11", size = 76632992, upload-time = "2026-04-23T23:35:36.851Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/17/5cd8da44188b115cd5b836d6bd293e242d7533c15aa9e4ad634024f9c182/claude_agent_sdk-0.1.66-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:10abd64e5f8dc65eb2f592c1d4db5607129ef983ecabdfd5ecf4b2692ee02293", size = 76610323, upload-time = "2026-04-23T23:35:42.639Z" },
+    { url = "https://files.pythonhosted.org/packages/90/fc/205a918b36e118370942e464578bb6637ffb2c749c63d8d1c634d4e3aefd/claude_agent_sdk-0.1.66-py3-none-win_amd64.whl", hash = "sha256:729984e3198bb62c96387b6c4bbe433eca2eb439abe5663c1bf1532e9e340d2b", size = 78346312, upload-time = "2026-04-23T23:35:48.219Z" },
 ]
 
 [[package]]
@@ -3691,7 +3692,7 @@ dev = [
     { name = "boto3", specifier = ">=1.28.57" },
     { name = "botocore", specifier = ">=1.31.57" },
     { name = "celery", specifier = ">=5.4.0" },
-    { name = "claude-agent-sdk", marker = "python_full_version >= '3.10'", specifier = ">=0" },
+    { name = "claude-agent-sdk", marker = "python_full_version >= '3.10'", specifier = ">=0.1.62" },
     { name = "cloudpickle", specifier = ">=3.0.0" },
     { name = "coverage", extras = ["toml"], marker = "python_full_version < '3.10'", specifier = ">=7.5.0" },
     { name = "coverage", extras = ["toml"], marker = "python_full_version >= '3.10'", specifier = ">=7.13.0" },


### PR DESCRIPTION
Closes #2.

## Summary

The Claude Agent SDK yields `RateLimitEvent` and `MirrorErrorMessage` through `receive_response()`, but the existing integration's match loop only branched on `Assistant/User/Result`, so both were silently dropped — invisible in logfire.

Adds two `elif` branches in `patched_receive_response` and two helpers:

- **`_record_rate_limit_event`** — log span scoped to the root `invoke_agent` span. Severity tracks the SDK `status`: `rejected` → error (plus `error.type=RateLimitRejected` and `root_span.set_level('error')`), `allowed_warning` → warn, else info. Records semconv-named attrs (`gen_ai.rate_limit.status/type/utilization/resets_at` + overage equivalents) **plus** `gen_ai.rate_limit.raw` — the SDK's forward-compat escape hatch carrying any fields we don't yet model.

- **`_record_mirror_error`** — error-level log with `error.type=MirrorError`. `SessionKey` is unpacked into `gen_ai.conversation.id` (session_id), `mirror.project_key`, `mirror.subpath`. The raw dict isn't serialized whole — logfire's default scrubber matches the substring `session` in attribute values and would redact the blob.

## SDK-drift safety

SDK types resolved via `getattr(claude_agent_sdk, 'RateLimitEvent', None)` so older versions without the types still import cleanly. Requires `claude-agent-sdk >= 0.1.62` for the cassette test to actually execute (skipped below that). Pin bumped in `pyproject.toml`; `uv.lock` updated.

## New semconv constants

8 new `RATE_LIMIT_*` constants in the shared `llm_providers/semconv.py`. Follows the existing pattern (every other `gen_ai.*` in the integration is a named constant). The attributes duplicate what's in `.raw` (snake_case named attrs for filtering/dashboards, original camelCase in `.raw` for passthrough) — standard OTel pattern.

## Tests

- `test_ratelimit_and_mirror_error_cassette` — cassette replay through the real `SubprocessCLITransport` via `fake_claude.py`. Cassette is hand-assembled (`ratelimit_mirror_conversation.json`) since `mirror_error` is SDK-synthesized and `rate_limit_event` requires a real rate-limit transition. Assertion via `inline_snapshot.snapshot([...])` matching upstream PR #1799's style.
- `test_rate_limit_rejected_sets_error_level` — `SimpleNamespace` unit for the `rejected` escalation path.
- `test_mirror_error_without_key` — None-key branch.

## Empirical verification

Live run against real Anthropic API through `ClaudeSDKClient` with a wrapping Transport that splices synthetic `rate_limit_event` and `mirror_error` messages post-init. Captured via in-memory OTel span exporter **and** the logfire UI:

- Before patch: both events dropped silently (baseline confirmed).
- After patch: `rate_limit allowed_warning` (level=warn) and `mirror store error: ...` (level=error) nested under `invoke_agent`, with `gen_ai.rate_limit.raw` expandable as a JSON object in the UI, and `mirror.project_key` / `mirror.subpath` surfacing unscrubbed.

Full trace: https://logfire-eu.pydantic.dev/mehmet/discovering-cc (service `issue-02-ratelimit-mirror`).

## Notes for upstream

Reviewed adversarially by Opus and Sonnet subagents before commit. Addressed P1s (raw dict forward-compat, full SessionKey unpacking, semconv constants, pin bump) and Must-match style items (`getattr` guard pattern, inline_snapshot assertion style, typed `msg` params with forward refs, file-level imports).

Pre-existing failure in `test_tool_use_conversation_cassette` on `main` is unrelated to this change — the `code.filepath: _callers.py` symptom reproduces with the current branch checked out on `main`.

## Test plan

- [x] 19 passed, 1 deselected (the pre-existing `test_tool_use_conversation_cassette` failure).
- [x] `test_logfire_api` — 3 passed, 1 skipped (no public API change, stubs unaffected).
- [x] Empirical end-to-end through real Anthropic API + logfire UI.
- [x] Zero scrubbing hits.