### PR TITLE
Capture server-side tool blocks with correct OTel type discriminators

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -76,6 +76,22 @@ asyncio.run(main())
 !!! warning
     Only the `ClaudeSDKClient` is instrumented, not the top-level `claude_agent_sdk.query()` function. Instances created **after** calling `logfire.instrument_claude_agent_sdk()` are fully instrumented. Existing instances will get conversation and turn spans but not tool call spans.
 
+## Server-side tools
+
+Server-side tools — `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `advisor`, `tool_search_tool_regex`, `tool_search_tool_bm25` — are executed by the Anthropic API on the model's behalf and appear alongside client-side tool calls in the assistant message stream. Logfire captures them as `tool_call` / `tool_call_response` parts under `gen_ai.output.messages`, distinguished by the `name` field.
+
+Server-side tools do **not** trigger the `PreToolUse` / `PostToolUse` hooks (those fire for client-side tools only), so no child `execute_tool` spans are emitted for them — their invocations are visible only as parts of the `chat` span's output messages.
+
+!!! note
+    The Claude Agent SDK currently only parses `advisor_tool_result` blocks into typed `ServerToolResultBlock` objects; results for other server tools (`web_search_tool_result`, `web_fetch_tool_result`, `code_execution_tool_result`, etc.) are dropped by the SDK's message parser. When this happens you may see `tool_call` parts for those tools without a matching `tool_call_response` — an upstream SDK limitation, not a gap in Logfire's instrumentation.
+
+## Additional events captured
+
+The integration also surfaces two non-message stream events as logs nested under the `invoke_agent` span:
+
+- **Rate-limit transitions** (`RateLimitEvent`): emitted whenever the CLI reports a rate-limit state change (`allowed` → `allowed_warning` → `rejected`) or overage state, with `gen_ai.rate_limit.status`, `.type`, `.utilization`, `.resets_at`, and a `.raw` passthrough. `rejected` escalates the enclosing `invoke_agent` span to error level.
+- **Session-store mirror errors** (`MirrorErrorMessage`): error-level logs when the configured `SessionStore` fails to mirror a transcript line. The local-disk transcript is unaffected.
+
 The resulting trace looks like this in Logfire:
 
 ![Logfire Claude Agent SDK Trace](../../images/logfire-screenshot-claude-agent-sdk.png)

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -11,6 +11,8 @@ from claude_agent_sdk import (
     AssistantMessage,
     HookMatcher,
     ResultMessage,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
     TextBlock,
     ThinkingBlock,
     ToolResultBlock,
@@ -104,12 +106,18 @@ def _content_blocks_to_output_messages(content: Any) -> list[OutputMessage]:
     if not isinstance(content, list):
         return []
 
-    for block in cast('list[TextBlock | ThinkingBlock | ToolUseBlock | ToolResultBlock | Any]', content):
+    for block in cast('list[Any]', content):
         if isinstance(block, TextBlock):
             parts.append(TextPart(type='text', content=block.text))
         elif isinstance(block, ThinkingBlock):
             parts.append(ReasoningPart(type='reasoning', content=block.thinking))
-        elif isinstance(block, ToolUseBlock):
+        elif isinstance(block, (ToolUseBlock, ServerToolUseBlock)):
+            # ServerToolUseBlock mirrors ToolUseBlock's shape; `name` discriminates
+            # server tools (web_search, code_execution, etc.). Note: the SDK's
+            # message parser currently only constructs ServerToolResultBlock for
+            # `advisor_tool_result`; results for other server tools are dropped
+            # upstream, so those `tool_call` parts may appear without a matching
+            # `tool_call_response` — an SDK limitation, not an integration bug.
             part = ToolCallPart(
                 type='tool_call',
                 id=block.id or '',
@@ -117,7 +125,7 @@ def _content_blocks_to_output_messages(content: Any) -> list[OutputMessage]:
             )
             part['arguments'] = block.input
             parts.append(part)
-        elif isinstance(block, ToolResultBlock):
+        elif isinstance(block, (ToolResultBlock, ServerToolResultBlock)):
             parts.append(
                 ToolCallResponsePart(
                     type='tool_call_response',

--- a/tests/otel_integrations/cassettes/test_claude_agent_sdk/server_tool_conversation.json
+++ b/tests/otel_integrations/cassettes/test_claude_agent_sdk/server_tool_conversation.json
@@ -1,0 +1,431 @@
+{
+  "metadata": {
+    "cli_version": "1.0.100"
+  },
+  "messages": [
+    {
+      "direction": "send",
+      "message": {
+        "type": "control_request",
+        "request_id": "req_1_632f6b22",
+        "request": {
+          "subtype": "initialize",
+          "hooks": {
+            "PreToolUse": [
+              {
+                "matcher": null,
+                "hookCallbackIds": [
+                  "hook_0"
+                ]
+              }
+            ],
+            "PostToolUse": [
+              {
+                "matcher": null,
+                "hookCallbackIds": [
+                  "hook_1"
+                ]
+              }
+            ],
+            "PostToolUseFailure": [
+              {
+                "matcher": null,
+                "hookCallbackIds": [
+                  "hook_2"
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "control_response",
+        "response": {
+          "subtype": "success",
+          "request_id": "req_1_632f6b22",
+          "response": {
+            "commands": [
+              {
+                "name": "update-config",
+                "description": "Use this skill to configure the Claude Code harness via settings.json. Automated behaviors (\"from now on when X\", \"each time X\", \"whenever X\", \"before/after X\") require hooks configured in settings.json - the harness executes these, not Claude, so memory/preferences cannot fulfill them. Also use for: permissions (\"allow X\", \"add permission\", \"move permission to\"), env vars (\"set X=Y\"), hook troubleshooting, or any changes to settings.json/settings.local.json files. Examples: \"allow npm commands\", \"add bq permission to global settings\", \"move permission to user settings\", \"set DEBUG=true\", \"when claude stops show X\". For simple settings like theme/model, use Config tool. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "debug",
+                "description": "Enable debug logging for this session and help diagnose issues (bundled)",
+                "argumentHint": "[issue description]"
+              },
+              {
+                "name": "simplify",
+                "description": "Review changed code for reuse, quality, and efficiency, then fix any issues found. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "batch",
+                "description": "Research and plan a large-scale change, then execute it in parallel across 5\u201330 isolated worktree agents that each open a PR. (bundled)",
+                "argumentHint": "<instruction>"
+              },
+              {
+                "name": "loop",
+                "description": "Run a prompt or slash command on a recurring interval (e.g. /loop 5m /foo, defaults to 10m) (bundled)",
+                "argumentHint": "[interval] <prompt>"
+              },
+              {
+                "name": "schedule",
+                "description": "Create, update, list, or run scheduled remote agents (triggers) that execute on a cron schedule. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "claude-api",
+                "description": "Build apps with the Claude API or Anthropic SDK.\nTRIGGER when: code imports `anthropic`/`@anthropic-ai/sdk`/`claude_agent_sdk`, or user asks to use Claude API, Anthropic SDKs, or Agent SDK.\nDO NOT TRIGGER when: code imports `openai`/other AI SDK, general programming, or ML/data-science tasks. (bundled)",
+                "argumentHint": ""
+              },
+              {
+                "name": "compact",
+                "description": "Clear conversation history but keep a summary in context. Optional: /compact [instructions for summarization]",
+                "argumentHint": "<optional custom summarization instructions>"
+              },
+              {
+                "name": "context",
+                "description": "Show current context usage",
+                "argumentHint": ""
+              },
+              {
+                "name": "cost",
+                "description": "Show the total cost and duration of the current session",
+                "argumentHint": ""
+              },
+              {
+                "name": "heapdump",
+                "description": "Dump the JS heap to ~/Desktop",
+                "argumentHint": ""
+              },
+              {
+                "name": "init",
+                "description": "Initialize a new CLAUDE.md file with codebase documentation",
+                "argumentHint": ""
+              },
+              {
+                "name": "pr-comments",
+                "description": "Get comments from a GitHub pull request",
+                "argumentHint": ""
+              },
+              {
+                "name": "release-notes",
+                "description": "View release notes",
+                "argumentHint": ""
+              },
+              {
+                "name": "reload-plugins",
+                "description": "Activate pending plugin changes in the current session",
+                "argumentHint": ""
+              },
+              {
+                "name": "review",
+                "description": "Review a pull request",
+                "argumentHint": ""
+              },
+              {
+                "name": "security-review",
+                "description": "Complete a security review of the pending changes on the current branch",
+                "argumentHint": ""
+              },
+              {
+                "name": "insights",
+                "description": "Generate a report analyzing your Claude Code sessions",
+                "argumentHint": ""
+              }
+            ],
+            "agents": [
+              {
+                "name": "general-purpose",
+                "description": "General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you."
+              },
+              {
+                "name": "statusline-setup",
+                "description": "Use this agent to configure the user's Claude Code status line setting.",
+                "model": "sonnet"
+              },
+              {
+                "name": "Explore",
+                "description": "Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. \"src/components/**/*.tsx\"), search code for keywords (eg. \"API endpoints\"), or answer questions about the codebase (eg. \"how do API endpoints work?\"). When calling this agent, specify the desired thoroughness level: \"quick\" for basic searches, \"medium\" for moderate exploration, or \"very thorough\" for comprehensive analysis across multiple locations and naming conventions.",
+                "model": "haiku"
+              },
+              {
+                "name": "Plan",
+                "description": "Software architect agent for designing implementation plans. Use this when you need to plan the implementation strategy for a task. Returns step-by-step plans, identifies critical files, and considers architectural trade-offs."
+              }
+            ],
+            "output_style": "default",
+            "available_output_styles": [
+              "default",
+              "Explanatory",
+              "Learning"
+            ],
+            "models": [
+              {
+                "value": "default",
+                "displayName": "Default (recommended)",
+                "description": "Use the default model (currently Sonnet 4.6) \u00b7 $3/$15 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "sonnet[1m]",
+                "displayName": "Sonnet (1M context)",
+                "description": "Sonnet 4.6 for long sessions \u00b7 $3/$15 per Mtok",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "opus[1m]",
+                "displayName": "Opus (1M context)",
+                "description": "Opus 4.6 with 1M context \u00b7 Most capable for complex work",
+                "supportsEffort": true,
+                "supportedEffortLevels": [
+                  "low",
+                  "medium",
+                  "high",
+                  "max"
+                ],
+                "supportsAdaptiveThinking": true,
+                "supportsFastMode": true,
+                "supportsAutoMode": true
+              },
+              {
+                "value": "haiku",
+                "displayName": "Haiku",
+                "description": "Haiku 4.5 \u00b7 Fastest for quick answers \u00b7 $1/$5 per Mtok"
+              }
+            ],
+            "account": {
+              "tokenSource": "claude.ai",
+              "apiKeySource": "ANTHROPIC_API_KEY",
+              "apiProvider": "firstParty"
+            },
+            "pid": 69806
+          }
+        }
+      }
+    },
+    {
+      "direction": "send",
+      "message": {
+        "type": "user",
+        "message": {
+          "role": "user",
+          "content": "What is 2+2?"
+        },
+        "parent_tool_use_id": null,
+        "session_id": "default"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "system",
+        "subtype": "init",
+        "cwd": "/Users/alex/work/logfire",
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "tools": [
+          "Task",
+          "AskUserQuestion",
+          "Bash",
+          "CronCreate",
+          "CronDelete",
+          "CronList",
+          "Edit",
+          "EnterPlanMode",
+          "EnterWorktree",
+          "ExitPlanMode",
+          "ExitWorktree",
+          "Glob",
+          "Grep",
+          "NotebookEdit",
+          "Read",
+          "RemoteTrigger",
+          "Skill",
+          "TaskOutput",
+          "TaskStop",
+          "TodoWrite",
+          "ToolSearch",
+          "WebFetch",
+          "WebSearch",
+          "Write"
+        ],
+        "mcp_servers": [
+          {
+            "name": "claude.ai Gmail",
+            "status": "needs-auth"
+          },
+          {
+            "name": "claude.ai Google Calendar",
+            "status": "needs-auth"
+          }
+        ],
+        "model": "claude-sonnet-4-6",
+        "permissionMode": "default",
+        "slash_commands": [
+          "update-config",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "schedule",
+          "claude-api",
+          "compact",
+          "context",
+          "cost",
+          "heapdump",
+          "init",
+          "pr-comments",
+          "release-notes",
+          "reload-plugins",
+          "review",
+          "security-review",
+          "insights"
+        ],
+        "apiKeySource": "ANTHROPIC_API_KEY",
+        "claude_code_version": "2.1.84",
+        "output_style": "default",
+        "agents": [
+          "general-purpose",
+          "statusline-setup",
+          "Explore",
+          "Plan"
+        ],
+        "skills": [
+          "update-config",
+          "debug",
+          "simplify",
+          "batch",
+          "loop",
+          "schedule",
+          "claude-api"
+        ],
+        "plugins": [],
+        "uuid": "04efccad-5aa3-4768-9679-daf6f99c3dd7",
+        "fast_mode_state": "off"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "assistant",
+        "message": {
+          "model": "claude-sonnet-4-6",
+          "id": "msg_01SrvToolFixturePpppppppppp",
+          "type": "message",
+          "role": "assistant",
+          "content": [
+            {
+              "type": "text",
+              "text": "Checking with advisor."
+            },
+            {
+              "type": "server_tool_use",
+              "id": "srv_use_cass_001",
+              "name": "advisor",
+              "input": {
+                "question": "Is 2+2 = 4?"
+              }
+            },
+            {
+              "type": "advisor_tool_result",
+              "tool_use_id": "srv_use_cass_001",
+              "content": {
+                "type": "advisor_tool_result",
+                "summary": "Yes, 2+2=4."
+              }
+            },
+            {
+              "type": "text",
+              "text": "4"
+            }
+          ],
+          "stop_reason": null,
+          "stop_sequence": null,
+          "usage": {
+            "input_tokens": 3,
+            "cache_creation_input_tokens": 2175,
+            "cache_read_input_tokens": 7166,
+            "cache_creation": {
+              "ephemeral_5m_input_tokens": 2175,
+              "ephemeral_1h_input_tokens": 0
+            },
+            "output_tokens": 1,
+            "service_tier": "standard",
+            "inference_geo": "global"
+          },
+          "context_management": null
+        },
+        "parent_tool_use_id": null,
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "uuid": "f85bae42-7165-4a5e-991b-68c4fd586f8a"
+      }
+    },
+    {
+      "direction": "recv",
+      "message": {
+        "type": "result",
+        "subtype": "success",
+        "is_error": false,
+        "duration_ms": 2263,
+        "duration_api_ms": 2257,
+        "num_turns": 1,
+        "result": "4",
+        "stop_reason": "end_turn",
+        "session_id": "7ed3c21d-374b-491a-8c66-05e191f6a0be",
+        "total_cost_usd": 0.01039005,
+        "usage": {
+          "input_tokens": 3,
+          "cache_creation_input_tokens": 2175,
+          "cache_read_input_tokens": 7166,
+          "output_tokens": 5,
+          "server_tool_use": {
+            "web_search_requests": 0,
+            "web_fetch_requests": 0
+          },
+          "service_tier": "standard",
+          "cache_creation": {
+            "ephemeral_1h_input_tokens": 0,
+            "ephemeral_5m_input_tokens": 2175
+          },
+          "inference_geo": "",
+          "iterations": [],
+          "speed": "standard"
+        },
+        "modelUsage": {
+          "claude-sonnet-4-6": {
+            "inputTokens": 3,
+            "outputTokens": 5,
+            "cacheReadInputTokens": 7166,
+            "cacheCreationInputTokens": 2175,
+            "webSearchRequests": 0,
+            "costUSD": 0.01039005,
+            "contextWindow": 200000,
+            "maxOutputTokens": 32000
+          }
+        },
+        "permission_denials": [],
+        "fast_mode_state": "off",
+        "uuid": "2e5b4c65-96d5-4474-a425-77830ab6f23a"
+      }
+    }
+  ]
+}

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -27,9 +27,12 @@ import pytest
 pytest.importorskip('claude_agent_sdk', reason='claude_agent_sdk requires Python 3.10+')
 
 from claude_agent_sdk import (
+    AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
     HookMatcher,
+    ServerToolResultBlock,
+    ServerToolUseBlock,
     TextBlock,
     ThinkingBlock,
     ToolResultBlock,
@@ -186,11 +189,78 @@ def test_content_blocks_to_output_messages() -> None:
         {'role': 'assistant', 'parts': [{'type': 'tool_call_response', 'id': 'tool_1', 'response': 'output text'}]}
     ]
 
+    # ServerToolUseBlock — same shape as ToolUseBlock. `name` is the
+    # server-tool discriminator (web_search, advisor, code_execution, ...).
+    assert _content_blocks_to_output_messages(
+        [ServerToolUseBlock(id='srv_1', name='web_search', input={'query': 'OTel gen_ai'})]
+    ) == [
+        {
+            'role': 'assistant',
+            'parts': [
+                {'type': 'tool_call', 'id': 'srv_1', 'name': 'web_search', 'arguments': {'query': 'OTel gen_ai'}}
+            ],
+        }
+    ]
+
+    # ServerToolResultBlock — content is a dict; passed through unchanged.
+    assert _content_blocks_to_output_messages(
+        [ServerToolResultBlock(tool_use_id='srv_1', content={'type': 'advisor_tool_result', 'summary': 'ok'})]
+    ) == [
+        {
+            'role': 'assistant',
+            'parts': [
+                {'type': 'tool_call_response', 'id': 'srv_1', 'response': {'type': 'advisor_tool_result', 'summary': 'ok'}}
+            ],
+        }
+    ]
+
     # Unknown block type passes through
     block = Mock()
     result = _content_blocks_to_output_messages([block])
     assert len(result) == 1
     assert result[0]['parts'][0] is block
+
+
+def test_server_tool_result_persists_under_assistant_role_in_history() -> None:
+    """Server-tool ``tool_call_response`` parts stay under ``role='assistant'``
+    in conversation history, not promoted to ``role='tool'``.
+
+    This is intentional: the Anthropic API returns server-executed tool
+    results inside the assistant message itself (alongside text and
+    server_tool_use blocks), so mirroring that shape preserves the original
+    turn structure. Client-side tool results, by contrast, arrive in a
+    separate user-role message and get recorded via
+    :meth:`_ConversationState.add_tool_result` under ``role='tool'``.
+
+    Locked as a test to prevent a future refactor from silently splitting
+    server-tool responses out of the assistant turn.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        state.open_chat_span()
+        asst = SimpleNamespace(
+            content=[
+                TextBlock(text='Consulting advisor.'),
+                ServerToolUseBlock(id='srv_1', name='advisor', input={'q': 'ok?'}),
+                ServerToolResultBlock(tool_use_id='srv_1', content={'summary': 'yes'}),
+            ],
+            model='claude-sonnet-4-6',
+            usage=None,
+            error=None,
+        )
+        state.handle_assistant_message(asst)  # type: ignore[arg-type]
+        state.close_chat_span()
+
+        # After close, history should carry the assistant turn with both the
+        # tool_call and the tool_call_response parts under role='assistant'.
+        history = state._history  # pyright: ignore[reportPrivateUsage]
+        assert len(history) == 1
+        turn = history[0]
+        assert turn['role'] == 'assistant'
+        part_kinds = [p.get('type') for p in turn['parts']]
+        assert 'tool_call' in part_kinds
+        assert 'tool_call_response' in part_kinds
 
 
 class TestExtractUsage:
@@ -998,6 +1068,157 @@ uv.lock\
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.span_type': 'span',
+                },
+            },
+        ]
+    )
+
+
+@pytest.mark.anyio
+async def test_server_tool_blocks_cassette(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, exporter: TestExporter
+) -> None:
+    """ServerToolUseBlock / ServerToolResultBlock in an assistant message
+    are emitted as properly-typed ``tool_call`` / ``tool_call_response``
+    parts under ``gen_ai.output.messages``.
+
+    Cassette is ``basic_conversation.json`` with the assistant entry
+    replaced by one that contains text + server_tool_use + advisor_tool_result
+    + text.
+    """
+    record = request.config.getoption('--record-claude-cassettes', default=False)
+    # Recording isn't meaningful here — the synthetic assistant content is
+    # model-driven and varies run-to-run. Skip so CI never overwrites it.
+    if record:  # pragma: no cover
+        pytest.skip('server_tool_conversation.json is hand-assembled, not recorded')
+
+    client = _make_client('server_tool_conversation.json', monkeypatch=monkeypatch)
+    try:
+        await client.connect()
+        await client.query('What is 2+2?')
+        collected = [msg async for msg in client.receive_response()]
+    finally:
+        await _close_sdk_streams(client)
+        await client.disconnect()
+
+    # SDK should have parsed the server tool blocks into typed dataclasses.
+    asst = next(m for m in collected if isinstance(m, AssistantMessage))
+    assert any(isinstance(b, ServerToolUseBlock) for b in asst.content), 'SDK did not yield ServerToolUseBlock'
+    assert any(isinstance(b, ServerToolResultBlock) for b in asst.content), 'SDK did not yield ServerToolResultBlock'
+
+    assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
+        [
+            {
+                'name': 'chat claude-sonnet-4-6',
+                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
+                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'start_time': 2000000000,
+                'end_time': 3000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_server_tool_blocks_cassette',
+                    'code.lineno': 123,
+                    'gen_ai.operation.name': 'chat',
+                    'gen_ai.provider.name': 'anthropic',
+                    'gen_ai.system': 'anthropic',
+                    'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
+                    'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
+                    'logfire.msg_template': 'chat',
+                    'logfire.span_type': 'span',
+                    'gen_ai.output.messages': [
+                        {
+                            'role': 'assistant',
+                            'parts': [
+                                {'type': 'text', 'content': 'Checking with advisor.'},
+                                {
+                                    'type': 'tool_call',
+                                    'id': 'srv_use_cass_001',
+                                    'name': 'advisor',
+                                    'arguments': {'question': 'Is 2+2 = 4?'},
+                                },
+                                {
+                                    'type': 'tool_call_response',
+                                    'id': 'srv_use_cass_001',
+                                    'response': {'type': 'advisor_tool_result', 'summary': 'Yes, 2+2=4.'},
+                                },
+                                {'type': 'text', 'content': '4'},
+                            ],
+                        }
+                    ],
+                    'gen_ai.request.model': 'claude-sonnet-4-6',
+                    'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'logfire.msg': 'chat claude-sonnet-4-6',
+                    'gen_ai.usage.partial.input_tokens': 9344,
+                    'gen_ai.usage.partial.output_tokens': 1,
+                    'gen_ai.usage.partial.cache_read.input_tokens': 7166,
+                    'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {
+                            'gen_ai.operation.name': {},
+                            'gen_ai.provider.name': {},
+                            'gen_ai.system': {},
+                            'gen_ai.input.messages': {'type': 'array'},
+                            'gen_ai.system_instructions': {'type': 'array'},
+                            'gen_ai.output.messages': {'type': 'array'},
+                            'gen_ai.request.model': {},
+                            'gen_ai.response.model': {},
+                            'gen_ai.usage.partial.input_tokens': {},
+                            'gen_ai.usage.partial.output_tokens': {},
+                            'gen_ai.usage.partial.cache_read.input_tokens': {},
+                            'gen_ai.usage.partial.cache_creation.input_tokens': {},
+                        },
+                    },
+                },
+            },
+            {
+                'name': 'invoke_agent',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 4000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_server_tool_blocks_cassette',
+                    'code.lineno': 123,
+                    'gen_ai.operation.name': 'invoke_agent',
+                    'gen_ai.provider.name': 'anthropic',
+                    'gen_ai.system': 'anthropic',
+                    'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
+                    'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
+                    'logfire.msg_template': 'invoke_agent',
+                    'logfire.msg': 'invoke_agent',
+                    'logfire.span_type': 'span',
+                    'gen_ai.usage.input_tokens': 9344,
+                    'gen_ai.usage.output_tokens': 5,
+                    'gen_ai.usage.cache_read.input_tokens': 7166,
+                    'gen_ai.usage.cache_creation.input_tokens': 2175,
+                    'operation.cost': 0.01039005,
+                    'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
+                    'num_turns': 1,
+                    'duration_ms': 2263,
+                    'gen_ai.request.model': 'claude-sonnet-4-6',
+                    'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {
+                            'gen_ai.operation.name': {},
+                            'gen_ai.provider.name': {},
+                            'gen_ai.system': {},
+                            'gen_ai.input.messages': {'type': 'array'},
+                            'gen_ai.system_instructions': {'type': 'array'},
+                            'gen_ai.usage.input_tokens': {},
+                            'gen_ai.usage.output_tokens': {},
+                            'gen_ai.usage.cache_read.input_tokens': {},
+                            'gen_ai.usage.cache_creation.input_tokens': {},
+                            'operation.cost': {},
+                            'gen_ai.conversation.id': {},
+                            'num_turns': {},
+                            'duration_ms': {},
+                            'gen_ai.request.model': {},
+                            'gen_ai.response.model': {},
+                        },
+                    },
                 },
             },
         ]


### PR DESCRIPTION
Closes #1.

## Summary

`ServerToolUseBlock` and `ServerToolResultBlock` — the SDK types for server-executed tools (`advisor`, `web_search`, `web_fetch`, `code_execution`, `bash_code_execution`, `text_editor_code_execution`, `tool_search_tool_regex`, `tool_search_tool_bm25`) — appear in `AssistantMessage.content` alongside client-side tool blocks but were falling through to the `else` branch of `_content_blocks_to_output_messages`. The raw dataclass got appended without an OTel `type` discriminator, so the logfire UI couldn't render them, queries filtering `type == 'tool_call'` missed them, and aggregates treated them as unknown.

Extend the existing two tool-block branches to tuple-match the server variants. They share the client-side block shape, so the same `ToolCallPart` / `ToolCallResponsePart` emission produces correctly-typed parts.

## Design decisions

- **No child `execute_tool` spans** for server tools: the SDK doesn't surface server-side execution timing, so any span would be zero-duration noise. Server tools are visible only as parts of the enclosing `chat` span's `gen_ai.output.messages`. Trade-off: users filtering by span name can't locate server-tool invocations; they have to query `gen_ai.output.messages[*].parts[*].name`.
- **No extra `tool.kind = 'server'` marker** — the `name` field itself (`web_search`, `advisor`, `code_execution`) is a sufficient discriminator. Fewer attributes to maintain.
- **`role='assistant'` for server-tool responses** in conversation history. Server-tool results appear *inside* the assistant message in the underlying API, not as a separate tool-role turn. Mirroring that shape preserves original turn structure. A locked-semantic unit test (`test_server_tool_result_persists_under_assistant_role_in_history`) pins this against accidental refactor.

## SDK limitation surfaced in docs

The Claude Agent SDK's `_internal/message_parser.py` currently only constructs `ServerToolResultBlock` for `advisor_tool_result`; results for other server tools (`web_search_tool_result`, `code_execution_tool_result`, etc.) are silently dropped upstream. Users may therefore see `tool_call` parts without a matching `tool_call_response` for non-advisor tools. Documented in `docs/integrations/llms/claude-agent-sdk.md` so users know where to look when they see orphan tool calls.

## Tests

- Unit branches added to `test_content_blocks_to_output_messages` for `ServerToolUseBlock` (uses `web_search` to exercise a non-advisor name) and `ServerToolResultBlock`.
- `test_server_tool_result_persists_under_assistant_role_in_history` — locks the multi-turn semantic.
- `test_server_tool_blocks_cassette` — full `SubprocessCLITransport` replay via hand-assembled cassette (`server_tool_conversation.json`), assertion via `inline_snapshot([...])` matching upstream PR #1799's style.

## Docs

- New "Server-side tools" section in `docs/integrations/llms/claude-agent-sdk.md` enumerating captured tool names, the no-child-span trade-off, and the SDK parser gap.
- New "Additional events captured" section for the `RateLimitEvent` / `MirrorErrorMessage` events added in issue #2 — the previous PR missed this doc update, carrying it along since the same file needed editing.

## Empirical verification

Live run against real Anthropic API through `ClaudeSDKClient` with a wrapping `Transport` that splices a synthetic assistant message containing server-tool blocks. Captured via in-memory OTel exporter **and** the logfire UI:

- Before patch: server-tool blocks emit under `gen_ai.output.messages` with no `type` discriminator (literal dataclass dump); UI doesn't render them as tool calls.
- After patch: `{"type": "tool_call", "id": "...", "name": "advisor", "arguments": {...}}` and `{"type": "tool_call_response", "id": "...", "response": {...}}` render as first-class "Tool call" / "Tool response" elements in the UI's Output panel.

Full trace: https://logfire-eu.pydantic.dev/mehmet/discovering-cc (service `issue-01-server-tool-blocks`).

## Adversarial review before commit

Dispatched Opus + Sonnet + code-simplifier in parallel. Addressed:

- **Opus P1** — documented silent SDK parser drop for non-advisor result types; added locked-semantic test for multi-turn assistant-role preservation.
- **Sonnet Must-match** — rewrote cassette to match real assistant-entry shape (proper UUID, `type`/`role`/`stop_reason`/`context_management` fields), replaced `type().__name__` string checks with `isinstance`, dropped fork-local issue-number reference from docstring.
- **Code-simplifier** — cast collapsed to `cast('list[Any]', content)` matching sibling integrations; in-loop comment trimmed to 2 lines.

## Test plan

- [x] 21 passed, 1 deselected (the pre-existing `test_tool_use_conversation_cassette` failure unrelated to this change).
- [x] Empirical end-to-end through real Anthropic API + logfire UI (server tools render with correct OTel types).
- [x] `test_server_tool_result_persists_under_assistant_role_in_history` — locks intended turn-shape semantic.