### PR TITLE
Refresh cassette cli_version metadata to bundled CLI 2.1.119

### DIFF
--- a/tests/otel_integrations/cassettes/test_claude_agent_sdk/basic_conversation.json
+++ b/tests/otel_integrations/cassettes/test_claude_agent_sdk/basic_conversation.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "cli_version": "1.0.100"
+    "cli_version": "2.1.119"
   },
   "messages": [
     {

--- a/tests/otel_integrations/cassettes/test_claude_agent_sdk/ratelimit_mirror_conversation.json
+++ b/tests/otel_integrations/cassettes/test_claude_agent_sdk/ratelimit_mirror_conversation.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "cli_version": "1.0.100"
+    "cli_version": "2.1.119"
   },
   "messages": [
     {

--- a/tests/otel_integrations/cassettes/test_claude_agent_sdk/server_tool_conversation.json
+++ b/tests/otel_integrations/cassettes/test_claude_agent_sdk/server_tool_conversation.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "cli_version": "1.0.100"
+    "cli_version": "2.1.119"
   },
   "messages": [
     {

--- a/tests/otel_integrations/cassettes/test_claude_agent_sdk/tool_use_conversation.json
+++ b/tests/otel_integrations/cassettes/test_claude_agent_sdk/tool_use_conversation.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "cli_version": "1.0.100"
+    "cli_version": "2.1.119"
   },
   "messages": [
     {


### PR DESCRIPTION
Closes #15.

## Summary

All four cassettes under ``tests/otel_integrations/cassettes/test_claude_agent_sdk/`` reported ``cli_version: 1.0.100`` — the ``fake_claude.py`` fallback, not an accurate record of the CLI the SDK currently bundles. ``claude-agent-sdk 0.1.66`` bundles CLI ``2.1.119`` (see ``claude_agent_sdk._cli_version.__cli_version__``).

## Impact

None on test behavior. The ``cli_version`` field is reported by the fake CLI when the SDK does a ``-v`` handshake, but no code in the SDK's replay path branches on it. Verified: 21 passed, 1 deselected (pre-existing ``test_tool_use_conversation_cassette`` failure on ``main``, unrelated).

## Scope

Four cassette JSON files, one line each. ``fake_claude.py``'s internal fallback defaults (also ``1.0.100``) are left alone — those represent "what to claim when we genuinely can't detect a real version" rather than "what our fixtures represent," so changing them is a different concern.

## Test plan

- [x] Full integration suite green.
- [x] Existing cassette replay tests (``test_basic_conversation_cassette``, ``test_ratelimit_and_mirror_error_cassette``, ``test_server_tool_blocks_cassette``) unaffected.