### PR TITLE
Capture ResultMessage conversation-level fields on invoke_agent span

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -92,6 +92,21 @@ The integration also surfaces two non-message stream events as logs nested under
 - **Rate-limit transitions** (`RateLimitEvent`): emitted whenever the CLI reports a rate-limit state change (`allowed` → `allowed_warning` → `rejected`) or overage state, with `gen_ai.rate_limit.status`, `.type`, `.utilization`, `.resets_at`, and a `.raw` passthrough. `rejected` escalates the enclosing `invoke_agent` span to error level.
 - **Session-store mirror errors** (`MirrorErrorMessage`): error-level logs when the configured `SessionStore` fails to mirror a transcript line. The local-disk transcript is unaffected.
 
+## End-of-conversation result fields
+
+The `invoke_agent` span carries the conversation-level summary extracted from `ResultMessage`:
+
+- `duration_api_ms` — time spent waiting on the Anthropic API (vs `duration_ms`, the total wall clock).
+- `gen_ai.response.finish_reasons` — the per-model stop reason as an OTel semconv array (e.g. `["end_turn"]`, `["max_tokens"]`).
+- `claude.result.subtype` — conversation-level end state: `success` / `error_max_turns` / `error_during_execution`. Distinct from `finish_reasons`.
+- `claude.result.text` — the final aggregated response text.
+- `claude.result.errors` — list of diagnostic error strings encountered during the run, if any.
+- `claude.result.structured_output` — the structured payload when `output_format` is configured.
+- `claude.model_usage` — per-model token breakdown (useful when `fallback_model` kicks in and the aggregate `gen_ai.usage.*` no longer attributes tokens to a single model).
+- `claude.permission_denials` — list of tool-permission denials recorded by the CLI.
+
+The `claude.*` attributes except `claude.permission_denials` are added to Logfire's scrubber allowlist so model-generated content and user-supplied schemas pass through intact. `claude.permission_denials` entries contain the caller-supplied `tool_input` (arbitrary user data) and deliberately remain subject to default scrubbing.
+
 The resulting trace looks like this in Logfire:
 
 ![Logfire Claude Agent SDK Trace](../../images/logfire-screenshot-claude-agent-sdk.png)

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -30,6 +30,12 @@ MirrorErrorMessage = getattr(claude_agent_sdk, 'MirrorErrorMessage', None)
 from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
+    CLAUDE_MODEL_USAGE,
+    CLAUDE_PERMISSION_DENIALS,
+    CLAUDE_RESULT_ERRORS,
+    CLAUDE_RESULT_STRUCTURED_OUTPUT,
+    CLAUDE_RESULT_SUBTYPE,
+    CLAUDE_RESULT_TEXT,
     CONVERSATION_ID,
     ERROR_TYPE,
     INPUT_MESSAGES,
@@ -45,6 +51,7 @@ from logfire._internal.integrations.llm_providers.semconv import (
     RATE_LIMIT_TYPE,
     RATE_LIMIT_UTILIZATION,
     REQUEST_MODEL,
+    RESPONSE_FINISH_REASONS,
     RESPONSE_MODEL,
     SYSTEM,
     SYSTEM_INSTRUCTIONS,
@@ -641,12 +648,41 @@ def _record_result(span: LogfireSpan, msg: ResultMessage) -> None:
     if session_id is not None:  # pragma: no branch
         attrs[CONVERSATION_ID] = session_id
 
-    for attr in ('num_turns', 'duration_ms'):
-        if (value := getattr(msg, attr, None)) is not None:  # pragma: no branch
-            attrs[attr] = value
+    # Pass-through if not None (preserves empty string / empty dict for
+    # ``claude.result.text`` and ``claude.result.structured_output``). These
+    # claude.* attributes are added to ``scrubbing.SAFE_KEYS`` so model-
+    # generated content and user-supplied schemas are not regex-scrubbed.
+    for src, dst in (
+        ('num_turns', 'num_turns'),
+        ('duration_ms', 'duration_ms'),
+        ('duration_api_ms', 'duration_api_ms'),
+        ('subtype', CLAUDE_RESULT_SUBTYPE),
+        ('result', CLAUDE_RESULT_TEXT),
+        ('structured_output', CLAUDE_RESULT_STRUCTURED_OUTPUT),
+    ):
+        if (value := getattr(msg, src, None)) is not None:
+            attrs[dst] = value
+
+    # OTel semconv: finish_reasons is an array even with a single value.
+    if (stop_reason := getattr(msg, 'stop_reason', None)) is not None:
+        attrs[RESPONSE_FINISH_REASONS] = [stop_reason]
+
+    # Per-model usage breakdown. Useful when fallback_model kicks in and
+    # aggregate gen_ai.usage.* no longer attributes tokens to one model.
+    if model_usage := getattr(msg, 'model_usage', None):
+        attrs[CLAUDE_MODEL_USAGE] = model_usage
+
+    # Truthy guards skip the empty-list happy path for these audit fields.
+    # Note: claude.permission_denials is NOT scrub-exempt — denial entries
+    # carry user-supplied ``tool_input`` where redaction is the safer default.
+    if denials := getattr(msg, 'permission_denials', None):
+        attrs[CLAUDE_PERMISSION_DENIALS] = denials
+
+    if errors := getattr(msg, 'errors', None):
+        attrs[CLAUDE_RESULT_ERRORS] = errors
 
     span.set_attributes(attrs)
 
     is_error = getattr(msg, 'is_error', None)
-    if is_error:  # pragma: no cover
+    if is_error:
         span.set_level('error')

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -102,6 +102,22 @@ RATE_LIMIT_OVERAGE_RESETS_AT = 'gen_ai.rate_limit.overage.resets_at'
 RATE_LIMIT_OVERAGE_DISABLED_REASON = 'gen_ai.rate_limit.overage.disabled_reason'
 RATE_LIMIT_RAW = 'gen_ai.rate_limit.raw'
 
+# Claude Agent SDK result-message fields (vendor-prefixed extensions; not in
+# upstream OTel gen-ai semconv). Surfaced from ResultMessage which summarises
+# the end-of-conversation state. The `text`, `errors`, `structured_output`,
+# `subtype`, and `model_usage` keys are added to the scrubber's SAFE_KEYS
+# allowlist — they carry model-generated content or deterministic enums/
+# numbers, where default regex-based scrubbing does more harm than good.
+# `permission_denials` is deliberately NOT on the allowlist: denial entries
+# include the caller-supplied ``tool_input`` which is genuinely arbitrary
+# user data where scrubbing is the safer default.
+CLAUDE_RESULT_SUBTYPE = 'claude.result.subtype'
+CLAUDE_RESULT_TEXT = 'claude.result.text'
+CLAUDE_RESULT_ERRORS = 'claude.result.errors'
+CLAUDE_RESULT_STRUCTURED_OUTPUT = 'claude.result.structured_output'
+CLAUDE_MODEL_USAGE = 'claude.model_usage'
+CLAUDE_PERMISSION_DENIALS = 'claude.permission_denials'
+
 # Type definitions for message parts and messages
 
 

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -167,6 +167,16 @@ class BaseScrubber(ABC):
         gen_ai_semconv.PROVIDER_NAME,
         gen_ai_semconv.REQUEST_MODEL,
         gen_ai_semconv.RESPONSE_MODEL,
+        # Claude Agent SDK ResultMessage fields carrying model-generated content
+        # or deterministic enums/numbers. See semconv.py for the rationale for
+        # each; ``claude.permission_denials`` is deliberately omitted (its
+        # entries carry user-supplied ``tool_input`` where scrubbing is the
+        # safer default).
+        gen_ai_semconv.CLAUDE_RESULT_TEXT,
+        gen_ai_semconv.CLAUDE_RESULT_ERRORS,
+        gen_ai_semconv.CLAUDE_RESULT_STRUCTURED_OUTPUT,
+        gen_ai_semconv.CLAUDE_RESULT_SUBTYPE,
+        gen_ai_semconv.CLAUDE_MODEL_USAGE,
     }
 
     @abstractmethod

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -51,6 +51,7 @@ from logfire._internal.integrations.claude_agent_sdk import (
     _inject_tracing_hooks,
     _record_mirror_error,
     _record_rate_limit_event,
+    _record_result,
     _set_state,
     post_tool_use_failure_hook,
     post_tool_use_hook,
@@ -209,7 +210,11 @@ def test_content_blocks_to_output_messages() -> None:
         {
             'role': 'assistant',
             'parts': [
-                {'type': 'tool_call_response', 'id': 'srv_1', 'response': {'type': 'advisor_tool_result', 'summary': 'ok'}}
+                {
+                    'type': 'tool_call_response',
+                    'id': 'srv_1',
+                    'response': {'type': 'advisor_tool_result', 'summary': 'ok'},
+                }
             ],
         }
     ]
@@ -219,6 +224,91 @@ def test_content_blocks_to_output_messages() -> None:
     result = _content_blocks_to_output_messages([block])
     assert len(result) == 1
     assert result[0]['parts'][0] is block
+
+
+@pytest.mark.anyio
+async def test_record_result_skips_empty_and_none_fields(exporter: TestExporter) -> None:
+    """``_record_result`` should only set attributes for fields with meaningful
+    values: empty lists (``errors=[]``, ``permission_denials=[]``) and
+    ``None`` values are skipped so happy-path spans don't carry always-empty
+    attributes.
+
+    Locked semantics:
+      * ``errors=[]``        → no ``claude.result.errors`` attribute
+      * ``permission_denials=[]`` → no ``claude.permission_denials``
+      * ``stop_reason=None`` → no ``gen_ai.response.finish_reasons``
+      * ``result=None``      → no ``claude.result.text``
+      * ``structured_output=None`` → no ``claude.result.structured_output``
+      * ``model_usage=None`` → no ``claude.model_usage``
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        msg = SimpleNamespace(
+            usage={'input_tokens': 100, 'output_tokens': 50},
+            total_cost_usd=0.01,
+            session_id='sess-abc',
+            num_turns=1,
+            duration_ms=1000,
+            duration_api_ms=900,
+            subtype='success',
+            stop_reason=None,
+            model_usage=None,
+            permission_denials=[],
+            errors=[],
+            result=None,
+            structured_output=None,
+            is_error=False,
+        )
+        _record_result(root, msg)  # type: ignore[arg-type]
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+
+    # Populated fields are present.
+    assert root_attrs['claude.result.subtype'] == 'success'
+    assert root_attrs['duration_api_ms'] == 900
+    assert root_attrs['num_turns'] == 1
+
+    # Empty / None fields are skipped.
+    for absent in (
+        'gen_ai.response.finish_reasons',
+        'claude.result.text',
+        'claude.model_usage',
+        'claude.permission_denials',
+        'claude.result.errors',
+        'claude.result.structured_output',
+    ):
+        assert absent not in root_attrs, f'{absent!r} should be skipped when empty/None'
+
+
+@pytest.mark.anyio
+async def test_record_result_is_error_escalates_span_level(exporter: TestExporter) -> None:
+    """A ResultMessage with ``is_error=True`` escalates the root span to error."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        msg = SimpleNamespace(
+            usage={'input_tokens': 10, 'output_tokens': 0},
+            total_cost_usd=0.0,
+            session_id='sess-xyz',
+            num_turns=3,
+            duration_ms=500,
+            duration_api_ms=400,
+            subtype='error_max_turns',
+            stop_reason=None,
+            model_usage=None,
+            permission_denials=[],
+            errors=['hit max_turns cap'],
+            result=None,
+            structured_output=None,
+            is_error=True,
+        )
+        _record_result(root, msg)  # type: ignore[arg-type]
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_span = next(s for s in spans if s['name'] == 'invoke_agent')
+    assert root_span['attributes']['logfire.level_num'] == 17  # error
+    assert root_span['attributes']['claude.result.subtype'] == 'error_max_turns'
+    assert root_span['attributes']['claude.result.errors'] == ['hit max_turns cap']
 
 
 def test_server_tool_result_persists_under_assistant_role_in_history() -> None:
@@ -710,6 +800,22 @@ async def test_basic_conversation_cassette(
                     'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
                     'num_turns': 1,
                     'duration_ms': 2263,
+                    'duration_api_ms': 2257,
+                    'claude.result.subtype': 'success',
+                    'claude.result.text': '4',
+                    'claude.model_usage': {
+                        'claude-sonnet-4-6': {
+                            'inputTokens': 3,
+                            'outputTokens': 5,
+                            'cacheReadInputTokens': 7166,
+                            'cacheCreationInputTokens': 2175,
+                            'webSearchRequests': 0,
+                            'costUSD': 0.01039005,
+                            'contextWindow': 200000,
+                            'maxOutputTokens': 32000,
+                        }
+                    },
+                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.json_schema': {
@@ -728,6 +834,11 @@ async def test_basic_conversation_cassette(
                             'gen_ai.conversation.id': {},
                             'num_turns': {},
                             'duration_ms': {},
+                            'duration_api_ms': {},
+                            'claude.result.subtype': {},
+                            'claude.result.text': {},
+                            'claude.model_usage': {'type': 'object'},
+                            'gen_ai.response.finish_reasons': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                         },
@@ -1197,6 +1308,22 @@ async def test_server_tool_blocks_cassette(
                     'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
                     'num_turns': 1,
                     'duration_ms': 2263,
+                    'duration_api_ms': 2257,
+                    'claude.result.subtype': 'success',
+                    'claude.result.text': '4',
+                    'claude.model_usage': {
+                        'claude-sonnet-4-6': {
+                            'inputTokens': 3,
+                            'outputTokens': 5,
+                            'cacheReadInputTokens': 7166,
+                            'cacheCreationInputTokens': 2175,
+                            'webSearchRequests': 0,
+                            'costUSD': 0.01039005,
+                            'contextWindow': 200000,
+                            'maxOutputTokens': 32000,
+                        }
+                    },
+                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.json_schema': {
@@ -1215,6 +1342,11 @@ async def test_server_tool_blocks_cassette(
                             'gen_ai.conversation.id': {},
                             'num_turns': {},
                             'duration_ms': {},
+                            'duration_api_ms': {},
+                            'claude.result.subtype': {},
+                            'claude.result.text': {},
+                            'claude.model_usage': {'type': 'object'},
+                            'gen_ai.response.finish_reasons': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                         },
@@ -1397,6 +1529,22 @@ async def test_ratelimit_and_mirror_error_cassette(
                     'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
                     'num_turns': 1,
                     'duration_ms': 2263,
+                    'duration_api_ms': 2257,
+                    'claude.result.subtype': 'success',
+                    'claude.result.text': '4',
+                    'claude.model_usage': {
+                        'claude-sonnet-4-6': {
+                            'inputTokens': 3,
+                            'outputTokens': 5,
+                            'cacheReadInputTokens': 7166,
+                            'cacheCreationInputTokens': 2175,
+                            'webSearchRequests': 0,
+                            'costUSD': 0.01039005,
+                            'contextWindow': 200000,
+                            'maxOutputTokens': 32000,
+                        }
+                    },
+                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.json_schema': {
@@ -1415,6 +1563,11 @@ async def test_ratelimit_and_mirror_error_cassette(
                             'gen_ai.conversation.id': {},
                             'num_turns': {},
                             'duration_ms': {},
+                            'duration_api_ms': {},
+                            'claude.result.subtype': {},
+                            'claude.result.text': {},
+                            'claude.model_usage': {'type': 'object'},
+                            'gen_ai.response.finish_reasons': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                         },


### PR DESCRIPTION
Closes #6.

## Summary

`_record_result` previously recorded only `usage`, `operation.cost`, `session_id`, `num_turns`, `duration_ms`, and escalated on `is_error`. The remaining eight ``ResultMessage`` fields were dropped. This PR captures them.

Scope was expanded during recon to include ``subtype`` (missed by the ticket — see the [recon comment](https://github.com/oneryalcin/logfire/issues/6#issuecomment-4316336872)), which discriminates conversation-level end state (``success`` / ``error_max_turns`` / ``error_during_execution``) — distinct from per-model ``stop_reason``.

## New attributes on `invoke_agent` root span

| SDK field | Attribute | Notes |
|---|---|---|
| ``duration_api_ms`` | ``duration_api_ms`` | Mirrors existing ``duration_ms`` |
| ``stop_reason`` | ``gen_ai.response.finish_reasons = [stop_reason]`` | Existing OTel semconv array |
| ``subtype`` | ``claude.result.subtype`` | End-state enum |
| ``result`` | ``claude.result.text`` | Final aggregated response text |
| ``errors`` | ``claude.result.errors`` | Diagnostic error strings |
| ``structured_output`` | ``claude.result.structured_output`` | ``output_format`` payload |
| ``model_usage`` | ``claude.model_usage`` | Per-model token breakdown |
| ``permission_denials`` | ``claude.permission_denials`` | Denied tool invocations |

## Scrubbing — critical fix

Initial pass placed the text under ``gen_ai.response.text`` under the (wrong) assumption that the entire ``gen_ai.*`` namespace is scrub-exempt. Adversarial review proved the claim false — only specific hardcoded names in ``BaseScrubber.SAFE_KEYS`` are exempt. Empirically reproduced: model output containing "password" was replaced with ``[Scrubbed due to 'password']``, ``errors=["authentication failed"]`` became ``[Scrubbed due to 'auth']``, and ``structured_output`` dict keys containing "session" were redacted. All silent data loss.

Fixed by:
1. Renaming all custom fields to the ``claude.*`` vendor-prefix (matches the ``claude_code.*`` pattern established by `claude-code-logfire-plugin`).
2. Adding the five model-content / deterministic attributes to ``BaseScrubber.SAFE_KEYS``.
3. Deliberately keeping ``claude.permission_denials`` scrubbed — denial entries carry caller-supplied ``tool_input`` which is genuinely arbitrary user data where scrubbing remains the safer default.

## Empirical verification

Harness (``empirical/issue_06_result_message_fields.py``) overlays scrub-triggering content onto the real CLI's result message:
- ``result`` contains the word "password"
- ``structured_output`` has a ``session_id`` key
- ``errors`` contains "authentication failed"

**Before patch (gen_ai.response.text path)**: all three scrubbed.
**After patch (claude.* + SAFE_KEYS)**: all three pass through intact, ``logfire.scrubbed`` marker absent from the span.

Confirmed via both the in-memory span exporter and the logfire UI. ``attributes_json_schema`` correctly types each new ``claude.*`` field.

## Tests

- ``test_record_result_skips_empty_and_none_fields`` — locks "populated-only" semantics so happy-path spans don't carry always-empty arrays.
- ``test_record_result_is_error_escalates_span_level`` — exercises ``is_error=True`` + ``subtype='error_max_turns'`` + non-empty ``errors``. Removes the pre-existing ``# pragma: no cover``.
- Inline_snapshots in three cassette tests (basic / server_tool / ratelimit_mirror) regenerated to carry the new attributes.

## Docs

New "End-of-conversation result fields" section in ``docs/integrations/llms/claude-agent-sdk.md`` enumerating the captured fields and documenting the scrubber allowlist decision explicitly (so users know ``claude.permission_denials`` remains subject to default scrubbing).

## Adversarial review before commit

- **Opus** caught the ``gen_ai.response.text`` scrubbing P0 and the ``gen_ai.response.text`` vs OTel registry squatting concern.
- **Sonnet** flagged the bare ``errors`` / ``subtype`` / ``model_usage`` names colliding with hypothetical future OTel additions.
- **Code-simplifier** folded the ``result`` / ``structured_output`` branches into the existing scalar loop in ``_record_result``.

All P0/must-match findings addressed.

## Test plan

- [x] 23 passed, 1 deselected (pre-existing ``test_tool_use_conversation_cassette`` failure on ``main``, unrelated).
- [x] Empirical harness with scrub-triggering content — all fields intact.
- [x] ``test_logfire_api`` — 3 passed, 1 skipped (no public API change).