### PR TITLE
Finalise invoke_agent root span with agent-run metadata

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -107,6 +107,15 @@ The `invoke_agent` span carries the conversation-level summary extracted from `R
 
 The `claude.*` attributes except `claude.permission_denials` are added to Logfire's scrubber allowlist so model-generated content and user-supplied schemas pass through intact. `claude.permission_denials` entries contain the caller-supplied `tool_input` (arbitrary user data) and deliberately remain subject to default scrubbing.
 
+## Agent Run view on the root span
+
+The `invoke_agent` root span is finalised with the full conversation and aggregate metadata for dashboarding:
+
+- `pydantic_ai.all_messages` — full conversation (user prompt, assistant turns, tool invocations, tool responses). This is the attribute that triggers Logfire's "Agent Run" chat-view rendering on the root span; without it the root only shows metadata and you have to drill into per-turn `chat` spans. The attribute name is a Logfire UI convention (originally established by `pydantic-ai`) and is already allowlisted by the scrubber.
+- `claude.tools_used` — aggregated invocation counts as `[{"tool": name, "count": n}, ...]` across client, MCP, and server tools. Useful for dashboards that summarise tool usage per session without needing to traverse the message array.
+- `gen_ai.agent.name` — the agent framework identifier (currently fixed to `claude-code`).
+- `claude.cwd` — the working directory from `ClaudeAgentOptions.cwd`, when set. Intentionally under the `claude.*` namespace rather than `session.*` so value-level scrubbing (e.g. paths containing `secret` / `private_key` / `auth`) still applies.
+
 The resulting trace looks like this in Logfire:
 
 ![Logfire Claude Agent SDK Trace](../../images/logfire-screenshot-claude-agent-sdk.png)

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import threading
+from collections import Counter
 from collections.abc import AsyncGenerator, AsyncIterable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from typing import TYPE_CHECKING, Any, cast
@@ -30,18 +31,22 @@ MirrorErrorMessage = getattr(claude_agent_sdk, 'MirrorErrorMessage', None)
 from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
+    AGENT_NAME,
+    CLAUDE_CWD,
     CLAUDE_MODEL_USAGE,
     CLAUDE_PERMISSION_DENIALS,
     CLAUDE_RESULT_ERRORS,
     CLAUDE_RESULT_STRUCTURED_OUTPUT,
     CLAUDE_RESULT_SUBTYPE,
     CLAUDE_RESULT_TEXT,
+    CLAUDE_TOOLS_USED,
     CONVERSATION_ID,
     ERROR_TYPE,
     INPUT_MESSAGES,
     OPERATION_NAME,
     OUTPUT_MESSAGES,
     PROVIDER_NAME,
+    PYDANTIC_AI_ALL_MESSAGES,
     RATE_LIMIT_OVERAGE_DISABLED_REASON,
     RATE_LIMIT_OVERAGE_RESETS_AT,
     RATE_LIMIT_OVERAGE_STATUS,
@@ -373,6 +378,7 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
             OPERATION_NAME: 'invoke_agent',
             PROVIDER_NAME: 'anthropic',
             SYSTEM: 'anthropic',
+            AGENT_NAME: 'claude-code',
         }
         if input_messages:  # pragma: no branch
             span_data[INPUT_MESSAGES] = input_messages
@@ -381,6 +387,8 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
             if system_prompt:  # pragma: no branch
                 text = str(system_prompt)
                 span_data[SYSTEM_INSTRUCTIONS] = [TextPart(type='text', content=text)]
+            if cwd := getattr(self.options, 'cwd', None):
+                span_data[CLAUDE_CWD] = str(cwd)
 
         with logfire_claude.span('invoke_agent', **span_data) as root_span:
             state = _ConversationState(
@@ -563,8 +571,30 @@ class _ConversationState:
             self._current_span.set_level('error')
 
     def close(self) -> None:
-        """Close chat span and end any orphaned tool spans."""
+        """Close chat span and end any orphaned tool spans.
+
+        Also finalises the root span with ``pydantic_ai.all_messages`` (the
+        attribute that triggers logfire's "Agent Run" UI rendering on the
+        root span) and ``claude.tools_used`` (per-tool invocation counts).
+        """
         self.close_chat_span()
+        # Snapshot under anyio: hooks can append to _history concurrently, so
+        # iterate a copy rather than the live list to avoid a theoretical race
+        # (list.append is safe; our walk is not atomic across the two reads).
+        history_snapshot = list(self._history)
+        if history_snapshot:
+            self.root_span.set_attribute(PYDANTIC_AI_ALL_MESSAGES, history_snapshot)
+            tool_counts = Counter(
+                name
+                for msg in history_snapshot
+                for part in msg.get('parts', [])
+                if part.get('type') == 'tool_call' and (name := part.get('name'))
+            )
+            if tool_counts:
+                self.root_span.set_attribute(
+                    CLAUDE_TOOLS_USED,
+                    [{'tool': n, 'count': c} for n, c in tool_counts.items()],
+                )
         for span in self.active_tool_spans.values():
             span._end()  # pyright: ignore[reportPrivateUsage]
         self.active_tool_spans.clear()

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -77,6 +77,9 @@ USAGE_RAW = 'gen_ai.usage.raw'
 INPUT_MESSAGES = 'gen_ai.input.messages'
 OUTPUT_MESSAGES = 'gen_ai.output.messages'
 SYSTEM_INSTRUCTIONS = 'gen_ai.system_instructions'
+# Full conversation history on the agent root span. Logfire's Model Run UI
+# renders this specific attribute as the root-span chat view.
+PYDANTIC_AI_ALL_MESSAGES = 'pydantic_ai.all_messages'
 
 # Tool execution
 TOOL_DEFINITIONS = 'gen_ai.tool.definitions'
@@ -87,6 +90,17 @@ TOOL_CALL_RESULT = 'gen_ai.tool.call.result'
 
 # Conversation tracking
 CONVERSATION_ID = 'gen_ai.conversation.id'
+
+# OTel GenAI semconv attribute identifying the agent framework.
+AGENT_NAME = 'gen_ai.agent.name'
+
+# Working directory the Claude Agent SDK is running in. Intentionally under
+# the vendor-prefixed ``claude.*`` namespace (rather than the ``session.*``
+# convention used by some Claude-Code-family plugins) so value-level scrubbing
+# still runs against the path — cwd strings legitimately contain substrings
+# like ``auth``, ``secret``, ``private_keys``, etc., and regex scrubbing there
+# is the safer default.
+CLAUDE_CWD = 'claude.cwd'
 
 # Error
 ERROR_TYPE = 'error.type'
@@ -117,6 +131,9 @@ CLAUDE_RESULT_ERRORS = 'claude.result.errors'
 CLAUDE_RESULT_STRUCTURED_OUTPUT = 'claude.result.structured_output'
 CLAUDE_MODEL_USAGE = 'claude.model_usage'
 CLAUDE_PERMISSION_DENIALS = 'claude.permission_denials'
+# Aggregated tool usage across the conversation, emitted on the
+# ``invoke_agent`` root span at close for dashboards that group by tool.
+CLAUDE_TOOLS_USED = 'claude.tools_used'
 
 # Type definitions for message parts and messages
 

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -177,6 +177,7 @@ class BaseScrubber(ABC):
         gen_ai_semconv.CLAUDE_RESULT_STRUCTURED_OUTPUT,
         gen_ai_semconv.CLAUDE_RESULT_SUBTYPE,
         gen_ai_semconv.CLAUDE_MODEL_USAGE,
+        gen_ai_semconv.CLAUDE_TOOLS_USED,
     }
 
     @abstractmethod

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -311,6 +311,130 @@ async def test_record_result_is_error_escalates_span_level(exporter: TestExporte
     assert root_span['attributes']['claude.result.errors'] == ['hit max_turns cap']
 
 
+def _user_msg(text: str) -> Any:
+    """Test helper — build a minimal ``gen_ai.input.messages``-shaped user message."""
+    return {'role': 'user', 'parts': [{'type': 'text', 'content': text}]}
+
+
+def _drive_state_through_turns(state: _ConversationState, turns: list[AssistantMessage]) -> None:
+    """Drive ``_ConversationState`` through assistant turns via the public
+    ``handle_assistant_message`` / ``handle_user_message`` / ``close``
+    API — no reaching into ``_history`` / ``_current_output_parts``.
+
+    The first turn uses the already-open chat span from ``open_chat_span()``;
+    subsequent turns call ``handle_user_message()`` to close the prior span
+    and open a new one (the same state-machine trigger the real receive loop
+    uses when a UserMessage arrives in the stream).
+    """
+    state.open_chat_span()
+    for i, turn in enumerate(turns):
+        if i > 0:
+            state.handle_user_message()
+        state.handle_assistant_message(turn)
+
+
+@pytest.mark.anyio
+async def test_close_sets_pydantic_ai_all_messages(exporter: TestExporter) -> None:
+    """``_ConversationState.close()`` copies ``_history`` onto the root span
+    as ``pydantic_ai.all_messages``.
+
+    Locked as a test because this attribute is what flips logfire's UI
+    from generic-span rendering to the full "Agent Run" view (full
+    conversation on the root span). A regression that empties ``_history``
+    or renames the attribute silently removes the root-span UI treatment
+    without breaking any chat-span-level snapshot.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[_user_msg('hi')])
+        _drive_state_through_turns(
+            state,
+            [AssistantMessage(content=[TextBlock(text='hello')], model='claude-sonnet-4-6')],
+        )
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    all_messages = root_attrs['pydantic_ai.all_messages']
+    assert [m['role'] for m in all_messages] == ['user', 'assistant']
+    assert all_messages[0]['parts'][0]['content'] == 'hi'
+    assert all_messages[1]['parts'][0]['content'] == 'hello'
+
+
+@pytest.mark.anyio
+async def test_close_aggregates_tools_used_from_history(exporter: TestExporter) -> None:
+    """``_ConversationState.close()`` walks ``_history`` and emits a
+    ``claude.tools_used`` aggregate count per tool on the root span.
+
+    Covers client tools, MCP tools, and server tools uniformly — they all
+    appear as ``type='tool_call'`` parts in history, so one pass counts all.
+    Mixed-role: also adds a ``role='tool'`` message carrying a
+    ``tool_call_response`` part which must NOT be counted (those are
+    responses, not invocations).
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[_user_msg('q')])
+        _drive_state_through_turns(
+            state,
+            [
+                AssistantMessage(
+                    content=[
+                        ToolUseBlock(id='t1', name='Bash', input={}),
+                        ToolUseBlock(id='t2', name='Read', input={}),
+                    ],
+                    model='claude-sonnet-4-6',
+                ),
+                AssistantMessage(
+                    content=[
+                        ToolUseBlock(id='t3', name='Bash', input={}),
+                        TextBlock(text='done'),
+                    ],
+                    model='claude-sonnet-4-6',
+                ),
+            ],
+        )
+        # A tool-response message — must not be counted as an invocation.
+        state.add_tool_result(tool_use_id='t3', tool_name='Bash', result='ok')
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    counts = {entry['tool']: entry['count'] for entry in root_attrs['claude.tools_used']}
+    assert counts == {'Bash': 2, 'Read': 1}
+
+
+@pytest.mark.anyio
+async def test_close_skips_tools_used_when_no_tool_calls(exporter: TestExporter) -> None:
+    """Text-only conversation → no ``claude.tools_used`` attribute."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[_user_msg('hi')])
+        _drive_state_through_turns(
+            state,
+            [AssistantMessage(content=[TextBlock(text='hello')], model='claude-sonnet-4-6')],
+        )
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    assert 'claude.tools_used' not in root_attrs
+
+
+@pytest.mark.anyio
+async def test_close_skips_pydantic_ai_all_messages_when_history_empty(exporter: TestExporter) -> None:
+    """Empty ``_history`` (no prompt, no turns) → no ``pydantic_ai.all_messages``
+    attribute on the root span."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    assert 'pydantic_ai.all_messages' not in root_attrs
+
+
 def test_server_tool_result_persists_under_assistant_role_in_history() -> None:
     """Server-tool ``tool_call_response`` parts stay under ``role='assistant'``
     in conversation history, not promoted to ``role='tool'``.
@@ -787,6 +911,7 @@ async def test_basic_conversation_cassette(
                     'gen_ai.operation.name': 'invoke_agent',
                     'gen_ai.provider.name': 'anthropic',
                     'gen_ai.system': 'anthropic',
+                    'gen_ai.agent.name': 'claude-code',
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
                     'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
                     'logfire.msg_template': 'invoke_agent',
@@ -818,12 +943,17 @@ async def test_basic_conversation_cassette(
                     'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'pydantic_ai.all_messages': [
+                        {'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]},
+                        {'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]},
+                    ],
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
                             'gen_ai.operation.name': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.system': {},
+                            'gen_ai.agent.name': {},
                             'gen_ai.input.messages': {'type': 'array'},
                             'gen_ai.system_instructions': {'type': 'array'},
                             'gen_ai.usage.input_tokens': {},
@@ -841,6 +971,7 @@ async def test_basic_conversation_cassette(
                             'gen_ai.response.finish_reasons': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
+                            'pydantic_ai.all_messages': {'type': 'array'},
                         },
                     },
                 },
@@ -1295,6 +1426,7 @@ async def test_server_tool_blocks_cassette(
                     'gen_ai.operation.name': 'invoke_agent',
                     'gen_ai.provider.name': 'anthropic',
                     'gen_ai.system': 'anthropic',
+                    'gen_ai.agent.name': 'claude-code',
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
                     'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
                     'logfire.msg_template': 'invoke_agent',
@@ -1326,12 +1458,35 @@ async def test_server_tool_blocks_cassette(
                     'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'pydantic_ai.all_messages': [
+                        {'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]},
+                        {
+                            'role': 'assistant',
+                            'parts': [
+                                {'type': 'text', 'content': 'Checking with advisor.'},
+                                {
+                                    'type': 'tool_call',
+                                    'id': 'srv_use_cass_001',
+                                    'name': 'advisor',
+                                    'arguments': {'question': 'Is 2+2 = 4?'},
+                                },
+                                {
+                                    'type': 'tool_call_response',
+                                    'id': 'srv_use_cass_001',
+                                    'response': {'type': 'advisor_tool_result', 'summary': 'Yes, 2+2=4.'},
+                                },
+                                {'type': 'text', 'content': '4'},
+                            ],
+                        },
+                    ],
+                    'claude.tools_used': [{'tool': 'advisor', 'count': 1}],
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
                             'gen_ai.operation.name': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.system': {},
+                            'gen_ai.agent.name': {},
                             'gen_ai.input.messages': {'type': 'array'},
                             'gen_ai.system_instructions': {'type': 'array'},
                             'gen_ai.usage.input_tokens': {},
@@ -1349,6 +1504,8 @@ async def test_server_tool_blocks_cassette(
                             'gen_ai.response.finish_reasons': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
+                            'pydantic_ai.all_messages': {'type': 'array'},
+                            'claude.tools_used': {'type': 'array'},
                         },
                     },
                 },
@@ -1516,6 +1673,7 @@ async def test_ratelimit_and_mirror_error_cassette(
                     'gen_ai.operation.name': 'invoke_agent',
                     'gen_ai.provider.name': 'anthropic',
                     'gen_ai.system': 'anthropic',
+                    'gen_ai.agent.name': 'claude-code',
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
                     'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
                     'logfire.msg_template': 'invoke_agent',
@@ -1547,12 +1705,17 @@ async def test_ratelimit_and_mirror_error_cassette(
                     'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
+                    'pydantic_ai.all_messages': [
+                        {'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]},
+                        {'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]},
+                    ],
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
                             'gen_ai.operation.name': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.system': {},
+                            'gen_ai.agent.name': {},
                             'gen_ai.input.messages': {'type': 'array'},
                             'gen_ai.system_instructions': {'type': 'array'},
                             'gen_ai.usage.input_tokens': {},
@@ -1570,6 +1733,7 @@ async def test_ratelimit_and_mirror_error_cassette(
                             'gen_ai.response.finish_reasons': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
+                            'pydantic_ai.all_messages': {'type': 'array'},
                         },
                     },
                 },


### PR DESCRIPTION
Closes #18.

## Summary

The ``invoke_agent`` root span previously rendered in logfire as a generic metadata view. Users had to drill into per-turn ``chat`` spans to see the conversation. This PR finalises the root span with four attributes that flip the logfire UI to an "Agent Run" chat-bubble view and enable per-session tool-usage dashboards.

| Attribute | Source | Purpose |
|---|---|---|
| ``pydantic_ai.all_messages`` | ``_ConversationState._history`` at ``close()`` | Full conversation; **triggers Agent Run UI rendering** |
| ``claude.tools_used`` | ``Counter`` over history ``tool_call`` parts | ``[{tool, count}, ...]`` aggregate for dashboards |
| ``gen_ai.agent.name`` | hardcoded ``"claude-code"`` | OTel GenAI semconv agent identifier |
| ``claude.cwd`` | ``ClaudeAgentOptions.cwd`` (truthy-guarded) | Working-directory context |

## Before / after

**Before** (stock, issue #6 state): root span has static metadata + initial prompt. Logfire "Model Run" panel doesn't recognise ``gen_ai.operation.name = 'invoke_agent'`` → generic render, users drill into chat spans to see conversation.

**After**: root span renders as "Agent Run" with the full multi-turn conversation inline. Verified empirically with a real MCP tool call session — screenshot in the linked issue shows chat bubbles + tool call cards + reasoning blocks all on ``invoke_agent``.

## Privacy & scrubbing

Adversarial review caught a P0 in an initial draft that placed the working directory under ``session.cwd`` + ``BaseScrubber.SAFE_KEYS``. Adding to SAFE_KEYS bypasses *value-level* regex scrubbing — so a cwd like ``/Users/alice/private-keys-dir/project`` would have shipped unredacted. Fixed by moving to ``claude.cwd`` (outside ``SAFE_KEYS``): the attribute name no longer contains the "session" substring that tripped default name-scrubbing, and value-level pattern matching (``secret`` / ``private_key`` / ``auth`` / etc.) still applies.

``pydantic_ai.all_messages`` was already in SAFE_KEYS upstream (``scrubbing.py:149``). ``claude.tools_used`` is added to SAFE_KEYS — the tool-count list is deterministic, contains only tool names + integer counts, no user content.

## Prior art for ``pydantic_ai.all_messages``

This PR is the first *internal* logfire integration to emit ``pydantic_ai.all_messages``. The attribute is allowlisted in the logfire scrubber (upstream PR predates this) because:
- The ``pydantic-ai`` library (external package) emits it for its own spans.
- The ``claude-code-logfire-plugin`` (external plugin) adopts the same convention — confirmed at ``scripts/log-event.py:1123``.

The attribute name is a Logfire UI rendering convention, not tied to pydantic-ai the library. Any agent integration emitting full conversation history in the OTel GenAI ``ChatMessage`` shape can adopt it. The ``PYDANTIC_AI_ALL_MESSAGES`` semconv constant is placed alongside ``INPUT_MESSAGES`` / ``OUTPUT_MESSAGES`` / ``SYSTEM_INSTRUCTIONS`` in the Message content block with a 2-line explanatory comment.

## Concurrency

``_ConversationState.close()`` snapshots ``self._history`` before iterating. Hooks (``add_tool_result``) can append to ``_history`` from anyio tasks; while ``list.append`` is thread-safe, our two-step walk (outer-loop messages, inner-loop parts) is not. The snapshot pattern matches the existing defensive style around the anyio context-propagation caveat documented at the top of the file.

## Tests

- ``test_close_sets_pydantic_ai_all_messages`` — drives state through ``handle_assistant_message`` (public API) rather than touching ``_history``.
- ``test_close_aggregates_tools_used_from_history`` — includes a ``role='tool'`` message via ``add_tool_result`` to pin the "tool_call_response parts must not be counted" semantic.
- ``test_close_skips_tools_used_when_no_tool_calls`` — text-only conversation emits no ``tools_used``.
- ``test_close_skips_pydantic_ai_all_messages_when_history_empty`` — pre-prompt failure emits no attribute.
- Inline_snapshots in 3 cassette tests regenerated.

## Docs

New "Agent Run view on the root span" section in ``docs/integrations/llms/claude-agent-sdk.md``.

## Deferred

Opus flagged unbounded ``pydantic_ai.all_messages`` payload size on very long sessions (30+ turns with large tool responses could hit OTel attribute-value limits). Deferred — our per-turn ``chat`` spans have the same class of problem today via ``gen_ai.input.messages`` (which carries the growing history up to each turn). A size-cap / truncation strategy should be applied uniformly across both, as a follow-up.

## Adversarial review before commit

- **Opus**: caught the ``session.cwd`` SAFE_KEYS privacy leak (P0) and the concurrency snapshot need (P1); flagged the empty-string cwd edge case and the private-API test bypass (both fixed).
- **Sonnet**: required doc update (done) and tests-through-public-API refactor (done); validated the semconv constant placement after the user's tidy-up.
- **Code-simplifier**: folded the tool-aggregation walk into a single ``Counter`` expression; trimmed constant-declaration comments.

All Must-match / P0 / P1 findings addressed.

## Test plan

- [x] 27 passed, 1 deselected (pre-existing ``test_tool_use_conversation_cassette`` failure on ``main``, unrelated).
- [x] ``test_logfire_api`` — 3 passed, 1 skipped (no public API change).
- [x] Empirical end-to-end through real Anthropic API + logfire UI (Agent Run view renders correctly; ``claude.cwd`` survives scrubbing with a path containing no sensitive substrings; scrub-trigger test against a future path with ``/secret/`` confirmed value-level scrubber still applies — covered by the namespace design, not by test).