### PR TITLE
Capture per-turn identifiers from AssistantMessage on chat spans

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -116,6 +116,17 @@ The `invoke_agent` root span is finalised with the full conversation and aggrega
 - `gen_ai.agent.name` — the agent framework identifier (currently fixed to `claude-code`).
 - `claude.cwd` — the working directory from `ClaudeAgentOptions.cwd`, when set. Intentionally under the `claude.*` namespace rather than `session.*` so value-level scrubbing (e.g. paths containing `secret` / `private_key` / `auth`) still applies.
 
+## Per-turn chat span attributes
+
+Each `chat` child span carries per-turn identifiers derived from the `AssistantMessage` that closed the turn:
+
+- `gen_ai.response.id` — the Anthropic API message id (e.g. `msg_01ABC...`). Directly queryable from the Anthropic API console.
+- `gen_ai.response.finish_reasons` — the per-turn stop reason as a single-element array (`["end_turn"]`, `["tool_use"]`, `["max_tokens"]`, …). Also surfaced on the `invoke_agent` root span from `ResultMessage.stop_reason` at conversation level — filter by span name when aggregating to avoid double-counting.
+- `claude.message.uuid` — the SDK-side stream UUID for the AssistantMessage. Distinct from `gen_ai.response.id` (the API id): useful for correlating with SDK-local logs or offline replays that don't hit the Anthropic API.
+- `claude.parent_tool_use_id` — set when an `AssistantMessage` is produced by a subagent spawned via a ToolUse; carries the parent ToolUse id for stitching subagent turns back to the parent agent's tool call.
+
+When the SDK emits multiple `AssistantMessage`s on the same chat span (text followed by a tool_use call from one API response, for example), these per-turn identifiers are last-write-wins — the final `message_id` / `stop_reason` is authoritative for the turn, matching the accumulating behaviour of `gen_ai.output.messages`.
+
 The resulting trace looks like this in Logfire:
 
 ![Logfire Claude Agent SDK Trace](../../images/logfire-screenshot-claude-agent-sdk.png)

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -33,7 +33,9 @@ from opentelemetry import context as context_api, trace as trace_api
 from logfire._internal.integrations.llm_providers.semconv import (
     AGENT_NAME,
     CLAUDE_CWD,
+    CLAUDE_MESSAGE_UUID,
     CLAUDE_MODEL_USAGE,
+    CLAUDE_PARENT_TOOL_USE_ID,
     CLAUDE_PERMISSION_DENIALS,
     CLAUDE_RESULT_ERRORS,
     CLAUDE_RESULT_STRUCTURED_OUTPUT,
@@ -57,6 +59,7 @@ from logfire._internal.integrations.llm_providers.semconv import (
     RATE_LIMIT_UTILIZATION,
     REQUEST_MODEL,
     RESPONSE_FINISH_REASONS,
+    RESPONSE_ID,
     RESPONSE_MODEL,
     SYSTEM,
     SYSTEM_INSTRUCTIONS,
@@ -564,6 +567,26 @@ class _ConversationState:
         usage = getattr(message, 'usage', None)
         if usage:  # pragma: no branch
             self._current_span.set_attributes(_extract_usage(usage, partial=True))
+
+        # Per-turn identifiers; see the CLAUDE_* constants' comment for the
+        # message_id / uuid / parent_tool_use_id distinction. When the SDK
+        # emits multiple AssistantMessages on the same chat span (e.g. text
+        # + tool_use from one API call), these are last-write-wins — the
+        # final message_id/stop_reason is the authoritative one for the
+        # turn, matching OUTPUT_MESSAGES which accumulates.
+        attrs: dict[str, Any] = {}
+        for src, dst in (
+            ('message_id', RESPONSE_ID),
+            ('uuid', CLAUDE_MESSAGE_UUID),
+            ('parent_tool_use_id', CLAUDE_PARENT_TOOL_USE_ID),
+        ):
+            if (value := getattr(message, src, None)) is not None:
+                attrs[dst] = value
+        # OTel semconv: finish_reasons is an array even with a single value.
+        if (stop_reason := getattr(message, 'stop_reason', None)) is not None:
+            attrs[RESPONSE_FINISH_REASONS] = [stop_reason]
+        if attrs:
+            self._current_span.set_attributes(attrs)
 
         error = getattr(message, 'error', None)
         if error:  # pragma: no cover

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -135,6 +135,12 @@ CLAUDE_PERMISSION_DENIALS = 'claude.permission_denials'
 # ``invoke_agent`` root span at close for dashboards that group by tool.
 CLAUDE_TOOLS_USED = 'claude.tools_used'
 
+# SDK-internal per-AssistantMessage ids, distinct from the Anthropic API
+# message_id captured under ``gen_ai.response.id``. ``parent_tool_use_id``
+# stitches subagent responses back to the ToolUse that spawned them.
+CLAUDE_MESSAGE_UUID = 'claude.message.uuid'
+CLAUDE_PARENT_TOOL_USE_ID = 'claude.parent_tool_use_id'
+
 # Type definitions for message parts and messages
 
 

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -435,6 +435,98 @@ async def test_close_skips_pydantic_ai_all_messages_when_history_empty(exporter:
     assert 'pydantic_ai.all_messages' not in root_attrs
 
 
+@pytest.mark.anyio
+async def test_handle_assistant_message_populates_per_turn_identifiers(exporter: TestExporter) -> None:
+    """All four per-turn identifiers land on the chat span when the
+    ``AssistantMessage`` carries them: ``gen_ai.response.id`` (Anthropic
+    message id), ``gen_ai.response.finish_reasons`` (per-turn stop reason),
+    ``claude.message.uuid`` (SDK stream id), ``claude.parent_tool_use_id``
+    (subagent stitching)."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[_user_msg('q')])
+        state.open_chat_span()
+        state.handle_assistant_message(
+            AssistantMessage(
+                content=[TextBlock(text='done')],
+                model='claude-sonnet-4-6',
+                message_id='msg_01ABC',
+                stop_reason='end_turn',
+                uuid='00000000-0000-0000-0000-000000000001',
+                parent_tool_use_id='toolu_01PARENT',
+            )
+        )
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat = next(s for s in spans if s['name'].startswith('chat'))
+    assert chat['attributes']['gen_ai.response.id'] == 'msg_01ABC'
+    assert chat['attributes']['gen_ai.response.finish_reasons'] == ['end_turn']
+    assert chat['attributes']['claude.message.uuid'] == '00000000-0000-0000-0000-000000000001'
+    assert chat['attributes']['claude.parent_tool_use_id'] == 'toolu_01PARENT'
+
+
+@pytest.mark.anyio
+async def test_handle_assistant_message_skips_missing_identifiers(exporter: TestExporter) -> None:
+    """An ``AssistantMessage`` with default (None) optional fields should
+    produce no per-turn identifier attributes — avoids emitting noise on
+    spans that carry only text content."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[_user_msg('q')])
+        state.open_chat_span()
+        state.handle_assistant_message(AssistantMessage(content=[TextBlock(text='done')], model='claude-sonnet-4-6'))
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat = next(s for s in spans if s['name'].startswith('chat'))
+    for absent in (
+        'gen_ai.response.id',
+        'gen_ai.response.finish_reasons',
+        'claude.message.uuid',
+        'claude.parent_tool_use_id',
+    ):
+        assert absent not in chat['attributes'], f'{absent!r} should be skipped when None'
+
+
+@pytest.mark.anyio
+async def test_handle_assistant_message_last_write_wins_across_sub_messages(exporter: TestExporter) -> None:
+    """Multiple ``AssistantMessage``s on the same chat span → per-turn
+    identifiers are last-write-wins (the final ``message_id`` /
+    ``stop_reason`` is authoritative for the turn, matching the accumulating
+    behaviour of ``OUTPUT_MESSAGES``).
+
+    Locked as a test so a refactor to first-write-wins or list-appending
+    is an explicit breaking change, not a silent one.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[_user_msg('q')])
+        state.open_chat_span()
+        state.handle_assistant_message(
+            AssistantMessage(
+                content=[TextBlock(text='thinking...')],
+                model='claude-sonnet-4-6',
+                message_id='msg_01FIRST',
+                stop_reason='tool_use',
+            )
+        )
+        state.handle_assistant_message(
+            AssistantMessage(
+                content=[TextBlock(text='done')],
+                model='claude-sonnet-4-6',
+                message_id='msg_01LAST',
+                stop_reason='end_turn',
+            )
+        )
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat = next(s for s in spans if s['name'].startswith('chat'))
+    assert chat['attributes']['gen_ai.response.id'] == 'msg_01LAST'
+    assert chat['attributes']['gen_ai.response.finish_reasons'] == ['end_turn']
+
+
 def test_server_tool_result_persists_under_assistant_role_in_history() -> None:
     """Server-tool ``tool_call_response`` parts stay under ``role='assistant'``
     in conversation history, not promoted to ``role='tool'``.
@@ -893,8 +985,12 @@ async def test_basic_conversation_cassette(
                             'gen_ai.usage.partial.output_tokens': {},
                             'gen_ai.usage.partial.cache_read.input_tokens': {},
                             'gen_ai.usage.partial.cache_creation.input_tokens': {},
+                            'gen_ai.response.id': {},
+                            'claude.message.uuid': {},
                         },
                     },
+                    'gen_ai.response.id': 'msg_01BxK8UH2LyuFLVXSPamqHam',
+                    'claude.message.uuid': 'ce1101bc-27c6-41b1-ae16-5edf06b0927c',
                     'logfire.span_type': 'span',
                 },
             },
@@ -1394,6 +1490,8 @@ async def test_server_tool_blocks_cassette(
                     'gen_ai.usage.partial.output_tokens': 1,
                     'gen_ai.usage.partial.cache_read.input_tokens': 7166,
                     'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
+                    'gen_ai.response.id': 'msg_01SrvToolFixturePpppppppppp',
+                    'claude.message.uuid': 'f85bae42-7165-4a5e-991b-68c4fd586f8a',
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
@@ -1409,6 +1507,8 @@ async def test_server_tool_blocks_cassette(
                             'gen_ai.usage.partial.output_tokens': {},
                             'gen_ai.usage.partial.cache_read.input_tokens': {},
                             'gen_ai.usage.partial.cache_creation.input_tokens': {},
+                            'gen_ai.response.id': {},
+                            'claude.message.uuid': {},
                         },
                     },
                 },
@@ -1641,6 +1741,8 @@ async def test_ratelimit_and_mirror_error_cassette(
                     'gen_ai.usage.partial.output_tokens': 1,
                     'gen_ai.usage.partial.cache_read.input_tokens': 7166,
                     'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
+                    'gen_ai.response.id': 'msg_01BxK8UH2LyuFLVXSPamqHam',
+                    'claude.message.uuid': 'ce1101bc-27c6-41b1-ae16-5edf06b0927c',
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
@@ -1656,6 +1758,8 @@ async def test_ratelimit_and_mirror_error_cassette(
                             'gen_ai.usage.partial.output_tokens': {},
                             'gen_ai.usage.partial.cache_read.input_tokens': {},
                             'gen_ai.usage.partial.cache_creation.input_tokens': {},
+                            'gen_ai.response.id': {},
+                            'claude.message.uuid': {},
                         },
                     },
                 },


### PR DESCRIPTION
Closes #7. Recon comment: https://github.com/oneryalcin/logfire/issues/7#issuecomment-4316826019

## Summary

``handle_assistant_message`` previously dropped four useful fields from every ``AssistantMessage``: ``message_id``, ``stop_reason``, ``uuid``, ``parent_tool_use_id``. This PR surfaces them as four per-turn attributes on the ``chat`` span.

| SDK field | Attribute | Rationale |
|---|---|---|
| ``message_id`` | ``gen_ai.response.id`` | Existing OTel semconv (``RESPONSE_ID``). Directly queryable from the Anthropic API console |
| ``stop_reason`` | ``gen_ai.response.finish_reasons = [stop_reason]`` | Existing semconv (``RESPONSE_FINISH_REASONS``). Per-turn — legitimately coexists with the conversation-level value on ``invoke_agent`` |
| ``uuid`` | ``claude.message.uuid`` | SDK-side stream id (distinct from API ``message_id``) — useful for offline replays |
| ``parent_tool_use_id`` | ``claude.parent_tool_use_id`` | Subagent stitching; load-bearing for issue #3 |

## Scope

Recon comment on the issue documents the one scope decision: ``AssistantMessage.session_id`` is the 5th optional field the ticket didn't mention; skipped because the conversation-level session id is already captured once on ``invoke_agent`` via ``ResultMessage → gen_ai.conversation.id``, and per-turn re-emission would be redundant.

## Scrubbing

No ``SAFE_KEYS`` changes required — all four values are short alphanumeric IDs (``msg_01...``, ``end_turn``, UUIDs, ``toolu_01...``) that don't match default scrub patterns, and the attribute names (``gen_ai.response.*`` / ``claude.*``) avoid scrub-trigger substrings.

## Guard style

Uses ``is not None`` to match ``_record_result``'s existing style for the same fields. A future SDK emitting an empty-string id is surfaced rather than silently swallowed.

## Tests

- ``test_handle_assistant_message_populates_per_turn_identifiers`` — all four attrs land when populated.
- ``test_handle_assistant_message_skips_missing_identifiers`` — None → no attribute.
- ``test_handle_assistant_message_last_write_wins_across_sub_messages`` — when the SDK emits multiple ``AssistantMessage``s on the same chat span (text + tool_use from one API call), the final ``message_id`` / ``stop_reason`` is authoritative. Locked as a test so a refactor to first-wins or list-appending is an explicit breaking change.
- Inline_snapshots in 3 cassette tests regenerated — real cassettes have ``message_id`` / ``uuid`` populated but ``stop_reason`` / ``parent_tool_use_id`` as None, so only those two new keys appear per chat span. ``finish_reasons`` coverage is unit-test-only; flagged explicitly.

## Docs

New "Per-turn chat span attributes" section in ``docs/integrations/llms/claude-agent-sdk.md`` enumerating the four attributes, documenting the last-write-wins semantic, and cross-referencing the duplicate ``finish_reasons`` on ``invoke_agent`` (filter by span name when aggregating).

## Adversarial review before commit

- **Opus**: caught the ``truthy vs is not None`` inconsistency with ``_record_result`` (fixed); flagged the multi-turn last-wins semantic as untested (fixed by adding ``test_..._last_write_wins_...``); flagged ``finish_reasons`` on both chat + invoke_agent as documentation-worthy (added to docs); debated ``claude.message.uuid`` redundancy with ``gen_ai.response.id`` (kept — distinct semantics for offline replay).
- **Sonnet**: flagged semconv-block placement (user-fixed: new block for per-turn constants); duplicated comment (simplified); split 2-scenario test into two (done); docs must-match (done).
- **Code-simplifier**: tuple-loop refactor replacing 4 walrus-if blocks.

All Must-match / P0 / P1 findings addressed. No P0s were found (the most serious item, scrubbing, was clean because values are short IDs).

## Test plan

- [x] 30 passed, 1 deselected (pre-existing ``test_tool_use_conversation_cassette`` failure on ``main``).
- [x] ``test_logfire_api`` — 3 passed, 1 skipped (no public API change).
- [x] Empirical end-to-end: harness synthesises a recognisable overlay (``msg_01TESTOVERLAY...``, ``tool_use``, a UUID, ``toolu_01PARENTTESTXX``) on every assistant message; all four attrs confirmed on the ``chat`` span in both the in-memory exporter and the Logfire UI (service ``issue-07-assistant-message-fields``).