### PR TITLE
Surface ClaudeAgentOptions session-config on invoke_agent root span

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -116,6 +116,18 @@ The `invoke_agent` root span is finalised with the full conversation and aggrega
 - `gen_ai.agent.name` — the agent framework identifier (currently fixed to `claude-code`).
 - `claude.cwd` — the working directory from `ClaudeAgentOptions.cwd`, when set. Intentionally under the `claude.*` namespace rather than `session.*` so value-level scrubbing (e.g. paths containing `secret` / `private_key` / `auth`) still applies.
 
+### Session configuration
+
+When the corresponding `ClaudeAgentOptions` field is set, the following attributes also appear on the `invoke_agent` root span. They're useful for filtering / grouping sessions in dashboards by configuration.
+
+- `claude.options.model` / `claude.options.fallback_model` — the model originally requested (distinct from `gen_ai.request.model` on the `chat` span which reflects the *actually used* model).
+- `claude.permission_mode`, `claude.max_turns`, `claude.max_budget_usd`, `claude.effort`.
+- `claude.allowed_tools`, `claude.disallowed_tools`, `claude.setting_sources`, `claude.agents` (custom-agent names only — `AgentDefinition` bodies are deliberately not serialised).
+- `claude.skills_mode` (`"all"` | `"allowlist"`) plus `claude.skills` (the list, in allowlist mode). The mixed `Literal["all"] | list[str]` SDK shape is normalised to a stable list type plus a discriminator so column-typed downstream stores see one schema.
+- `claude.continue_conversation`, `claude.include_partial_messages`, `claude.enable_file_checkpointing` — booleans, emitted only when `True` to keep happy-path spans noise-free.
+- `claude.resume_from` (from `ClaudeAgentOptions.resume`) and `claude.fork_on_resume` (from `fork_session`). Both renamed to drop the `session` substring that would otherwise trip the default scrubber's attribute-name match.
+- `ClaudeAgentOptions.user` is intentionally **not** surfaced. Although the SDK forces it to be a real Unix username, it remains host-level identity that users may legitimately want to keep out of every span. Operators who want it can record it themselves outside this integration.
+
 ## Per-turn chat span attributes
 
 Each `chat` child span carries per-turn identifiers derived from the `AssistantMessage` that closed the turn:

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -32,15 +32,32 @@ from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
     AGENT_NAME,
+    CLAUDE_AGENTS,
+    CLAUDE_ALLOWED_TOOLS,
+    CLAUDE_CONTINUE_CONVERSATION,
     CLAUDE_CWD,
+    CLAUDE_DISALLOWED_TOOLS,
+    CLAUDE_EFFORT,
+    CLAUDE_ENABLE_FILE_CHECKPOINTING,
+    CLAUDE_FORK_ON_RESUME,
+    CLAUDE_INCLUDE_PARTIAL_MESSAGES,
+    CLAUDE_MAX_BUDGET_USD,
+    CLAUDE_MAX_TURNS,
     CLAUDE_MESSAGE_UUID,
     CLAUDE_MODEL_USAGE,
+    CLAUDE_OPTIONS_FALLBACK_MODEL,
+    CLAUDE_OPTIONS_MODEL,
     CLAUDE_PARENT_TOOL_USE_ID,
     CLAUDE_PERMISSION_DENIALS,
+    CLAUDE_PERMISSION_MODE,
     CLAUDE_RESULT_ERRORS,
     CLAUDE_RESULT_STRUCTURED_OUTPUT,
     CLAUDE_RESULT_SUBTYPE,
     CLAUDE_RESULT_TEXT,
+    CLAUDE_RESUME_FROM,
+    CLAUDE_SETTING_SOURCES,
+    CLAUDE_SKILLS,
+    CLAUDE_SKILLS_MODE,
     CLAUDE_TOOLS_USED,
     CONVERSATION_ID,
     ERROR_TYPE,
@@ -201,6 +218,90 @@ def _extract_usage(usage: Any, *, partial: bool = False) -> dict[str, int]:
         result[f'{prefix}cache_creation.input_tokens'] = cache_creation
 
     return result
+
+
+def _options_attrs(options: Any) -> dict[str, Any]:
+    """Extract observability-relevant fields from ``ClaudeAgentOptions``.
+
+    Only fields that help dashboards / audits / debugging are surfaced.
+    Omits infrastructure-only fields (``cli_path``, ``env``, ``stderr``,
+    ``hooks``, ``session_store``, ``plugins``, ``sandbox``,
+    ``load_timeout_ms``), callables, and potentially-large configs
+    (``mcp_servers``, ``extra_args``, ``output_format`` schemas,
+    ``thinking`` / ``task_budget`` dicts).
+
+    Also intentionally omits ``user``: although the SDK calls ``getpwnam``
+    on it (forcing a real Unix username), it's host-level identity that
+    operators may legitimately want to keep out of every span. Operators
+    who want it can capture ``user`` themselves outside this integration.
+
+    ``resume`` and ``fork_session`` are surfaced under renamed keys
+    (``claude.resume_from`` / ``claude.fork_on_resume``) because the
+    original names contain the ``session`` substring which would trigger
+    the default logfire scrubber on the attribute name.
+    """
+    # Defensive isinstance — duck-typed mocks could otherwise silently
+    # emit garbage as attribute values (e.g. ``model=123`` ints).
+    if not isinstance(options, claude_agent_sdk.ClaudeAgentOptions):
+        return {}
+
+    attrs: dict[str, Any] = {}
+
+    # Scalars — emit when not None.
+    scalar_map: tuple[tuple[str, str], ...] = (
+        ('model', CLAUDE_OPTIONS_MODEL),
+        ('fallback_model', CLAUDE_OPTIONS_FALLBACK_MODEL),
+        ('permission_mode', CLAUDE_PERMISSION_MODE),
+        ('max_turns', CLAUDE_MAX_TURNS),
+        ('max_budget_usd', CLAUDE_MAX_BUDGET_USD),
+        ('effort', CLAUDE_EFFORT),
+        ('resume', CLAUDE_RESUME_FROM),
+    )
+    for src, dst in scalar_map:
+        if (value := getattr(options, src, None)) is not None:
+            attrs[dst] = value
+
+    # ``skills`` is ``list[str] | Literal["all"] | None``. Normalise the
+    # mixed-shape into a stable list-typed ``claude.skills`` plus a
+    # discriminator under ``claude.skills_mode`` so downstream typed
+    # stores (column-typed warehouses) see one shape.
+    if (skills := getattr(options, 'skills', None)) is not None:
+        if skills == 'all':
+            attrs[CLAUDE_SKILLS_MODE] = 'all'
+        else:
+            attrs[CLAUDE_SKILLS_MODE] = 'allowlist'
+            attrs[CLAUDE_SKILLS] = list(skills)
+
+    # Lists — emit when non-empty.
+    list_map: tuple[tuple[str, str], ...] = (
+        ('allowed_tools', CLAUDE_ALLOWED_TOOLS),
+        ('disallowed_tools', CLAUDE_DISALLOWED_TOOLS),
+        ('setting_sources', CLAUDE_SETTING_SOURCES),
+    )
+    for src, dst in list_map:
+        if value := getattr(options, src, None):
+            attrs[dst] = list(value)
+
+    # Booleans — emit only when True (non-default).
+    bool_map: tuple[tuple[str, str], ...] = (
+        ('continue_conversation', CLAUDE_CONTINUE_CONVERSATION),
+        ('include_partial_messages', CLAUDE_INCLUDE_PARTIAL_MESSAGES),
+        ('enable_file_checkpointing', CLAUDE_ENABLE_FILE_CHECKPOINTING),
+        ('fork_session', CLAUDE_FORK_ON_RESUME),
+    )
+    for src, dst in bool_map:
+        if getattr(options, src, False):
+            attrs[dst] = True
+
+    # ``agents`` is a dict of ``name → AgentDefinition``. Emit names only;
+    # only handle the dict shape because future SDK changes (e.g. to a
+    # ``list[AgentDefinition]``) would otherwise silently leak object
+    # reprs into the attribute.
+    agents = getattr(options, 'agents', None)
+    if isinstance(agents, dict) and agents:
+        attrs[CLAUDE_AGENTS] = sorted(agents.keys())
+
+    return attrs
 
 
 # ---------------------------------------------------------------------------
@@ -392,6 +493,7 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                 span_data[SYSTEM_INSTRUCTIONS] = [TextPart(type='text', content=text)]
             if cwd := getattr(self.options, 'cwd', None):
                 span_data[CLAUDE_CWD] = str(cwd)
+            span_data.update(_options_attrs(self.options))
 
         with logfire_claude.span('invoke_agent', **span_data) as root_span:
             state = _ConversationState(

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -141,6 +141,32 @@ CLAUDE_TOOLS_USED = 'claude.tools_used'
 CLAUDE_MESSAGE_UUID = 'claude.message.uuid'
 CLAUDE_PARENT_TOOL_USE_ID = 'claude.parent_tool_use_id'
 
+# ClaudeAgentOptions-derived attributes surfaced on the ``invoke_agent``
+# root span when the caller configured them. Names avoid the ``session``
+# substring (which would trip the default scrubber): ``resume`` →
+# ``resume_from``, ``fork_session`` → ``fork_on_resume``.
+CLAUDE_OPTIONS_MODEL = 'claude.options.model'
+CLAUDE_OPTIONS_FALLBACK_MODEL = 'claude.options.fallback_model'
+CLAUDE_PERMISSION_MODE = 'claude.permission_mode'
+CLAUDE_MAX_TURNS = 'claude.max_turns'
+CLAUDE_MAX_BUDGET_USD = 'claude.max_budget_usd'
+CLAUDE_ALLOWED_TOOLS = 'claude.allowed_tools'
+CLAUDE_DISALLOWED_TOOLS = 'claude.disallowed_tools'
+CLAUDE_EFFORT = 'claude.effort'
+CLAUDE_AGENTS = 'claude.agents'
+# ``skills`` on ClaudeAgentOptions is ``list[str] | Literal["all"] | None``.
+# We split the mixed shape into a discriminator + list so downstream
+# typed stores see one schema: ``claude.skills_mode`` is "all" or
+# "allowlist"; ``claude.skills`` is the list (omitted in "all" mode).
+CLAUDE_SKILLS_MODE = 'claude.skills_mode'
+CLAUDE_SKILLS = 'claude.skills'
+CLAUDE_SETTING_SOURCES = 'claude.setting_sources'
+CLAUDE_CONTINUE_CONVERSATION = 'claude.continue_conversation'
+CLAUDE_INCLUDE_PARTIAL_MESSAGES = 'claude.include_partial_messages'
+CLAUDE_ENABLE_FILE_CHECKPOINTING = 'claude.enable_file_checkpointing'
+CLAUDE_RESUME_FROM = 'claude.resume_from'
+CLAUDE_FORK_ON_RESUME = 'claude.fork_on_resume'
+
 # Type definitions for message parts and messages
 
 

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -145,6 +145,10 @@ CLAUDE_PARENT_TOOL_USE_ID = 'claude.parent_tool_use_id'
 # root span when the caller configured them. Names avoid the ``session``
 # substring (which would trip the default scrubber): ``resume`` →
 # ``resume_from``, ``fork_session`` → ``fork_on_resume``.
+# ``model`` and ``fallback_model`` carry the deeper ``.options.`` prefix to
+# disambiguate from per-turn ``gen_ai.request.model`` on chat spans. Other
+# options-derived attrs below are bare ``claude.<field>`` because they have
+# no collision in the existing namespace.
 CLAUDE_OPTIONS_MODEL = 'claude.options.model'
 CLAUDE_OPTIONS_FALLBACK_MODEL = 'claude.options.fallback_model'
 CLAUDE_PERMISSION_MODE = 'claude.permission_mode'

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -49,6 +49,7 @@ from logfire._internal.integrations.claude_agent_sdk import (
     _ConversationState,
     _extract_usage,
     _inject_tracing_hooks,
+    _options_attrs,
     _record_mirror_error,
     _record_rate_limit_event,
     _record_result,
@@ -525,6 +526,110 @@ async def test_handle_assistant_message_last_write_wins_across_sub_messages(expo
     chat = next(s for s in spans if s['name'].startswith('chat'))
     assert chat['attributes']['gen_ai.response.id'] == 'msg_01LAST'
     assert chat['attributes']['gen_ai.response.finish_reasons'] == ['end_turn']
+
+
+def test_options_attrs_full() -> None:
+    """``_options_attrs`` surfaces every observability-relevant field on the
+    invoke_agent root span when the caller populated it."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    opts = ClaudeAgentOptions(
+        model='claude-sonnet-4-6',
+        fallback_model='claude-haiku-4-5',
+        permission_mode='acceptEdits',
+        max_turns=5,
+        max_budget_usd=0.5,
+        allowed_tools=['Bash', 'Read'],
+        disallowed_tools=['WebFetch'],
+        effort='medium',
+        resume='prev-session-uuid',
+        skills=['skill_a', 'skill_b'],
+        setting_sources=['project'],
+        continue_conversation=True,
+        include_partial_messages=True,
+        enable_file_checkpointing=True,
+        fork_session=True,
+        agents={'reviewer': object(), 'planner': object()},  # type: ignore[dict-item]
+    )
+    attrs = _options_attrs(opts)
+    assert attrs == {
+        'claude.options.model': 'claude-sonnet-4-6',
+        'claude.options.fallback_model': 'claude-haiku-4-5',
+        'claude.permission_mode': 'acceptEdits',
+        'claude.max_turns': 5,
+        'claude.max_budget_usd': 0.5,
+        'claude.effort': 'medium',
+        'claude.resume_from': 'prev-session-uuid',
+        'claude.skills_mode': 'allowlist',
+        'claude.skills': ['skill_a', 'skill_b'],
+        'claude.allowed_tools': ['Bash', 'Read'],
+        'claude.disallowed_tools': ['WebFetch'],
+        'claude.setting_sources': ['project'],
+        'claude.continue_conversation': True,
+        'claude.include_partial_messages': True,
+        'claude.enable_file_checkpointing': True,
+        'claude.fork_on_resume': True,
+        'claude.agents': ['planner', 'reviewer'],
+    }
+
+
+def test_options_attrs_defaults_emit_nothing() -> None:
+    """A default-constructed ``ClaudeAgentOptions()`` yields no extra
+    attributes — keeps happy-path spans free of always-empty noise."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    assert _options_attrs(ClaudeAgentOptions()) == {}
+
+
+def test_options_attrs_renames_session_substrings() -> None:
+    """``resume`` and ``fork_session`` are surfaced under renamed attribute
+    keys (``claude.resume_from`` / ``claude.fork_on_resume``) because the
+    original names contain the ``session`` substring that triggers the
+    default scrubber on attribute names. Locked as a test so a refactor
+    that "fixes" the names back to the SDK field names regresses scrubbing.
+    """
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    opts = ClaudeAgentOptions(resume='r', fork_session=True)
+    attrs = _options_attrs(opts)
+    assert 'claude.resume_from' in attrs
+    assert 'claude.fork_on_resume' in attrs
+    assert not any('session' in k for k in attrs)
+
+
+def test_options_attrs_skills_all_normalises_to_mode_only() -> None:
+    """``skills='all'`` emits ``claude.skills_mode='all'`` and NO
+    ``claude.skills`` list — keeps the attribute schema stable as a list
+    type for downstream typed stores."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    attrs = _options_attrs(ClaudeAgentOptions(skills='all'))
+    assert attrs == {'claude.skills_mode': 'all'}
+
+
+def test_options_attrs_rejects_non_options_object() -> None:
+    """Defensive isinstance — duck-typed mocks emit nothing rather than
+    silently shipping garbage attribute values."""
+    from types import SimpleNamespace
+
+    fake = SimpleNamespace(
+        model=123,                       # wrong type
+        permission_mode=['nonsense'],    # wrong type
+        max_turns='five',                # wrong type
+    )
+    assert _options_attrs(fake) == {}
+
+
+def test_options_attrs_skips_non_dict_agents() -> None:
+    """``agents`` is typed ``dict[str, AgentDefinition] | None``. If a
+    future SDK change makes it a list, our extractor must skip rather
+    than emit ``[<AgentDefinition repr…>, …]``."""
+    from claude_agent_sdk import ClaudeAgentOptions
+
+    opts = ClaudeAgentOptions()
+    object.__setattr__(opts, 'agents', ['reviewer', 'planner'])  # simulate shape drift
+    attrs = _options_attrs(opts)
+    assert 'claude.agents' not in attrs
 
 
 def test_server_tool_result_persists_under_assistant_role_in_history() -> None:

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -531,8 +531,6 @@ async def test_handle_assistant_message_last_write_wins_across_sub_messages(expo
 def test_options_attrs_full() -> None:
     """``_options_attrs`` surfaces every observability-relevant field on the
     invoke_agent root span when the caller populated it."""
-    from claude_agent_sdk import ClaudeAgentOptions
-
     opts = ClaudeAgentOptions(
         model='claude-sonnet-4-6',
         fallback_model='claude-haiku-4-5',
@@ -576,8 +574,6 @@ def test_options_attrs_full() -> None:
 def test_options_attrs_defaults_emit_nothing() -> None:
     """A default-constructed ``ClaudeAgentOptions()`` yields no extra
     attributes — keeps happy-path spans free of always-empty noise."""
-    from claude_agent_sdk import ClaudeAgentOptions
-
     assert _options_attrs(ClaudeAgentOptions()) == {}
 
 
@@ -588,8 +584,6 @@ def test_options_attrs_renames_session_substrings() -> None:
     default scrubber on attribute names. Locked as a test so a refactor
     that "fixes" the names back to the SDK field names regresses scrubbing.
     """
-    from claude_agent_sdk import ClaudeAgentOptions
-
     opts = ClaudeAgentOptions(resume='r', fork_session=True)
     attrs = _options_attrs(opts)
     assert 'claude.resume_from' in attrs
@@ -601,8 +595,6 @@ def test_options_attrs_skills_all_normalises_to_mode_only() -> None:
     """``skills='all'`` emits ``claude.skills_mode='all'`` and NO
     ``claude.skills`` list — keeps the attribute schema stable as a list
     type for downstream typed stores."""
-    from claude_agent_sdk import ClaudeAgentOptions
-
     attrs = _options_attrs(ClaudeAgentOptions(skills='all'))
     assert attrs == {'claude.skills_mode': 'all'}
 
@@ -624,8 +616,6 @@ def test_options_attrs_skips_non_dict_agents() -> None:
     """``agents`` is typed ``dict[str, AgentDefinition] | None``. If a
     future SDK change makes it a list, our extractor must skip rather
     than emit ``[<AgentDefinition repr…>, …]``."""
-    from claude_agent_sdk import ClaudeAgentOptions
-
     opts = ClaudeAgentOptions()
     object.__setattr__(opts, 'agents', ['reviewer', 'planner'])  # simulate shape drift
     attrs = _options_attrs(opts)


### PR DESCRIPTION
Closes #8. Recon: https://github.com/oneryalcin/logfire/issues/8#issuecomment-4316908219

## Summary

Before this PR the integration captured exactly two of ``ClaudeAgentOptions``'s 34 fields on ``invoke_agent`` (``system_prompt``, ``cwd``). The other 32 were dropped — so dashboards couldn't filter sessions by model, permission_mode, max_turns, allowed_tools, custom agents, etc., and audit queries had no record of which guardrails the run was started with.

This PR adds ``_options_attrs(options)`` and ~16 ``claude.*`` attributes on the root span. Triage was documented in the recon comment up front; the patch surfaces only fields useful for dashboards / audits / debugging.

## Captured

- ``claude.options.model`` / ``claude.options.fallback_model`` — namespaced under ``.options.`` to disambiguate from per-turn ``gen_ai.request.model`` (the actually-used model on each ``chat`` span). Other fields use bare ``claude.<field>``.
- ``claude.permission_mode``, ``claude.max_turns``, ``claude.max_budget_usd``, ``claude.effort``.
- ``claude.allowed_tools``, ``claude.disallowed_tools``, ``claude.setting_sources``, ``claude.agents`` (sorted dict keys only — ``AgentDefinition`` bodies not serialised).
- ``claude.skills_mode`` (``"all"`` | ``"allowlist"``) + ``claude.skills`` (the list, in allowlist mode). The SDK's mixed ``Literal["all"] | list[str] | None`` shape is normalised so column-typed downstream stores see one schema.
- ``claude.continue_conversation``, ``claude.include_partial_messages``, ``claude.enable_file_checkpointing`` — booleans, only emitted when ``True``.
- ``claude.resume_from`` (from ``resume``) and ``claude.fork_on_resume`` (from ``fork_session``). **Renamed** to drop the ``session`` substring that would otherwise trip the default scrubber's attribute-name match.

## Privacy / safety decisions

- **``claude.user`` deliberately not surfaced.** Although the SDK forces the value to be a real Unix username via ``getpwnam``, it's still host-level identity that operators may legitimately want to keep out of every span. Documented in both the helper docstring and the user-facing docs.
- **Defensive ``isinstance(options, ClaudeAgentOptions)`` guard** at the top of ``_options_attrs`` — duck-typed mocks emit ``{}`` rather than silently shipping garbage attribute values (e.g. ``model=123`` ints).
- **``agents`` non-dict guard**: future SDK refactors changing the shape from ``dict`` to ``list`` won't silently leak ``AgentDefinition`` repr() strings into the attribute.

## Intentionally deferred (follow-up candidates)

- ``mcp_servers``, ``extra_args``, ``output_format``, ``thinking``, ``task_budget`` — all potentially-large dicts that need scrubber-aware extractors.
- ``cli_path``, ``env``, ``stderr``, ``hooks``, ``session_store``, ``plugins``, ``sandbox``, ``load_timeout_ms``, ``can_use_tool``, ``hooks`` — infrastructure-only / callables.

## Adversarial review before commit

- **Opus** caught the four most serious concerns up front: ``claude.user`` PII (dropped), mixed-shape ``skills`` (normalised), ``agents`` non-dict shape drift (guarded), duck-typed options shipping garbage (isinstance guard). All P0/P1 addressed.
- **Sonnet** flagged the namespace asymmetry between ``claude.options.model`` and bare ``claude.permission_mode`` (kept the asymmetry — model collides with per-turn ``gen_ai.request.model``, others don't — added an explanatory comment in ``semconv.py``); required hoisted test imports (done); required docs (done).
- **Code-simplifier** trimmed redundant docstring filler.

## Tests

- ``test_options_attrs_full`` — every populated field maps to the right attr.
- ``test_options_attrs_defaults_emit_nothing`` — ``ClaudeAgentOptions()`` emits ``{}``.
- ``test_options_attrs_renames_session_substrings`` — locks the rename so a refactor that "fixes" them back to the SDK field names regresses scrubbing safety.
- ``test_options_attrs_skills_all_normalises_to_mode_only`` — ``skills='all'`` emits ``claude.skills_mode`` only, no ``claude.skills`` list.
- ``test_options_attrs_rejects_non_options_object`` — ``SimpleNamespace`` mock with wrong-type fields → empty attrs (defensive guard).
- ``test_options_attrs_skips_non_dict_agents`` — simulates SDK shape drift via ``object.__setattr__``; ``claude.agents`` correctly skipped.

## Empirical verification

The harness configures a populated ``ClaudeAgentOptions`` and runs a real ``ClaudeSDKClient`` session. Every expected attribute lands on ``invoke_agent`` with the configured value; ``user`` and unset booleans / unset lists are correctly absent.

## Docs

New "Session configuration" subsection in ``docs/integrations/llms/claude-agent-sdk.md`` enumerating the attributes, rename rationale, and the deliberate omission of ``claude.user``.

## Test plan

- [x] 36 passed, 1 deselected (pre-existing ``test_tool_use_conversation_cassette`` failure on ``main``).
- [x] Empirical harness verifies every attr value end-to-end via real ``SubprocessCLITransport``.