### PR TITLE
Surface 5 unused Claude Agent SDK hook events as logfire log records

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -87,10 +87,23 @@ Server-side tools do **not** trigger the `PreToolUse` / `PostToolUse` hooks (tho
 
 ## Additional events captured
 
-The integration also surfaces two non-message stream events as logs nested under the `invoke_agent` span:
+The integration surfaces non-message stream events as logs nested under the `invoke_agent` span. Stream-source events:
 
 - **Rate-limit transitions** (`RateLimitEvent`): emitted whenever the CLI reports a rate-limit state change (`allowed` → `allowed_warning` → `rejected`) or overage state, with `gen_ai.rate_limit.status`, `.type`, `.utilization`, `.resets_at`, and a `.raw` passthrough. `rejected` escalates the enclosing `invoke_agent` span to error level.
 - **Session-store mirror errors** (`MirrorErrorMessage`): error-level logs when the configured `SessionStore` fails to mirror a transcript line. The local-disk transcript is unaffected.
+
+Hook-callback events (registered automatically on the `ClaudeAgentOptions.hooks` mapping):
+
+- **`Hook: UserPromptSubmit`** (info): emitted on every `client.query()` with `claude.user_prompt` carrying the submitted text and `gen_ai.conversation.id`. The prompt attribute deliberately stays subject to value-level scrubbing — user-typed prompts may contain credentials and default-on redaction is the safer privacy posture; deployments that need raw prompts can opt-out per-attribute via a `scrubbing_callback`.
+- **`Hook: Stop`** (info): emitted at end-of-turn with `claude.stop.last_assistant_message` (the verbatim final assistant text — model-generated content, allowlisted from scrubbing) and `claude.stop.hook_active` (only when `True`). The `last_assistant_message` field is captured defensively via `.get()` because the SDK type definition doesn't declare it; the integration silently skips it if a future SDK release renames the wire field.
+- **`Hook: PreCompact`** (warn): emitted before the CLI compacts the context window. Carries `claude.compact.trigger` (`"manual"` for `/compact` or `"auto"` for context-pressure triggered) and `claude.compact.custom_instructions` (operator-set guidance text, allowlisted from scrubbing). Warn level keeps it filterable / alertable as the strongest leading indicator of context pressure on long sessions.
+- **`Hook: Notification`** (info): emitted for CLI-emitted notifications. Carries `claude.notification.message`, `claude.notification.title` (when set), and `claude.notification.type`. The message attribute stays subject to default scrubbing because CLI-emitted text can evolve; allowlisting it would risk masking future regressions.
+- **`Hook: PermissionRequest`** (info): emitted as an audit log when the CLI requests permission to invoke a tool. Carries `gen_ai.tool.name`, `claude.permission_request.tool_input` (NOT allowlisted — caller-supplied arbitrary data, mirroring the `claude.permission_denials` precedent), `claude.permission_request.suggestions` when non-empty, and subagent attribution (`claude.agent_id` / `claude.agent_type`) when the request originates inside a subagent context.
+
+The `Hook:` prefix is a deliberate UX choice for trace readability — it makes hook-callback events visually distinct from SDK-generated stream events when scanning a session.
+
+!!! note "PermissionRequest, Notification, and PreCompact under non-interactive transport"
+    These three hooks are gated on interactive-TTY presence in the CLI. They typically don't fire during `ClaudeSDKClient` sessions running in scripted / non-interactive transport mode — even when the operations they describe are happening. The integration captures them when they do fire (e.g. inside an interactive terminal session) without requiring any opt-in. `UserPromptSubmit` and `Stop` fire on every query / turn and are always observable.
 
 ## End-of-conversation result fields
 
@@ -113,6 +126,7 @@ The `invoke_agent` root span is finalised with the full conversation and aggrega
 
 - `pydantic_ai.all_messages` — full conversation (user prompt, assistant turns, tool invocations, tool responses). This is the attribute that triggers Logfire's "Agent Run" chat-view rendering on the root span; without it the root only shows metadata and you have to drill into per-turn `chat` spans. The attribute name is a Logfire UI convention (originally established by `pydantic-ai`) and is already allowlisted by the scrubber.
 - `claude.tools_used` — aggregated invocation counts as `[{"tool": name, "count": n}, ...]` across client, MCP, and server tools. Useful for dashboards that summarise tool usage per session without needing to traverse the message array.
+- `claude.user_prompt_count` / `claude.compact_count` / `claude.notification_count` / `claude.permission_request_count` — per-conversation cumulative counts of the respective hook-callback events. Emitted only when non-zero so happy-path spans don't carry always-zero attrs. The bare `_count` suffix (rather than nesting under each event's sub-namespace) is intentional — these are root-span session aggregates, mirroring the `claude.tools_used` precedent.
 - `gen_ai.agent.name` — the agent framework identifier (currently fixed to `claude-code`).
 - `claude.cwd` — the working directory from `ClaudeAgentOptions.cwd`, when set. Intentionally under the `claude.*` namespace rather than `session.*` so value-level scrubbing (e.g. paths containing `secret` / `private_key` / `auth`) still applies.
 

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -32,8 +32,13 @@ from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
     AGENT_NAME,
+    CLAUDE_AGENT_ID,
+    CLAUDE_AGENT_TYPE,
     CLAUDE_AGENTS,
     CLAUDE_ALLOWED_TOOLS,
+    CLAUDE_COMPACT_COUNT,
+    CLAUDE_COMPACT_INSTRUCTIONS,
+    CLAUDE_COMPACT_TRIGGER,
     CLAUDE_CONTINUE_CONVERSATION,
     CLAUDE_CWD,
     CLAUDE_DISALLOWED_TOOLS,
@@ -45,11 +50,18 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_MAX_TURNS,
     CLAUDE_MESSAGE_UUID,
     CLAUDE_MODEL_USAGE,
+    CLAUDE_NOTIFICATION_COUNT,
+    CLAUDE_NOTIFICATION_MESSAGE,
+    CLAUDE_NOTIFICATION_TITLE,
+    CLAUDE_NOTIFICATION_TYPE,
     CLAUDE_OPTIONS_FALLBACK_MODEL,
     CLAUDE_OPTIONS_MODEL,
     CLAUDE_PARENT_TOOL_USE_ID,
     CLAUDE_PERMISSION_DENIALS,
     CLAUDE_PERMISSION_MODE,
+    CLAUDE_PERMISSION_REQUEST_COUNT,
+    CLAUDE_PERMISSION_REQUEST_SUGGESTIONS,
+    CLAUDE_PERMISSION_REQUEST_TOOL_INPUT,
     CLAUDE_RESULT_ERRORS,
     CLAUDE_RESULT_STRUCTURED_OUTPUT,
     CLAUDE_RESULT_SUBTYPE,
@@ -58,7 +70,11 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_SETTING_SOURCES,
     CLAUDE_SKILLS,
     CLAUDE_SKILLS_MODE,
+    CLAUDE_STOP_HOOK_ACTIVE,
+    CLAUDE_STOP_LAST_ASSISTANT_MESSAGE,
     CLAUDE_TOOLS_USED,
+    CLAUDE_USER_PROMPT,
+    CLAUDE_USER_PROMPT_COUNT,
     CONVERSATION_ID,
     ERROR_TYPE,
     INPUT_MESSAGES,
@@ -416,6 +432,124 @@ async def post_tool_use_failure_hook(
 
 
 # ---------------------------------------------------------------------------
+# Hook callbacks for non-tool-lifecycle events (issue #9).
+#
+# Empirically the SDK passes a freshly-allocated UUID as ``tool_use_id`` for
+# these events too — so the ``if not tool_use_id`` early-bail used by the
+# tool-lifecycle hooks above is intentionally absent here. Each callback is a
+# thin shim that runs a matching ``_record_*`` helper inside the root span's
+# OTel context (hooks run in different anyio tasks → contextvars don't
+# propagate; without explicit attach the emitted log lands as an orphan
+# top-level span rather than nested under ``invoke_agent``).
+# ---------------------------------------------------------------------------
+
+
+def _attach_root_context(state: _ConversationState) -> Any:
+    """Temporarily attach the root span as the active OTel context.
+
+    Mirrors the attach/detach pattern used by ``pre_tool_use_hook``. Returns
+    a token to pass to ``context_api.detach`` once the emission is done.
+    Returns ``None`` if the span is missing — caller should noop.
+    """
+    otel_span = state.root_span._span  # pyright: ignore[reportPrivateUsage]
+    if otel_span is None:  # pragma: no cover
+        return None
+    parent_ctx = trace_api.set_span_in_context(otel_span)
+    return context_api.attach(parent_ctx)
+
+
+async def _run_hook(
+    record_fn: Any,
+    input_data: Any,
+) -> None:
+    """Shared boilerplate for the 5 issue-#9 hook callbacks.
+
+    Each callback runs ``record_fn(state, input_data)`` inside the root
+    span's OTel context (hooks run in different anyio tasks so contextvars
+    don't propagate; without explicit attach the emitted log lands as an
+    orphan top-level span rather than nested under ``invoke_agent``).
+    """
+    with handle_internal_errors:
+        state = _get_state()
+        if state is None:  # pragma: no cover
+            return
+        token = _attach_root_context(state)
+        if token is None:  # pragma: no cover
+            return
+        try:
+            record_fn(state, input_data)
+        finally:
+            context_api.detach(token)
+
+
+async def user_prompt_submit_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Surface the prompt the user just submitted as an info-level log."""
+    await _run_hook(_record_user_prompt_submit, input_data)
+    return {}
+
+
+async def stop_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Surface the end-of-turn Stop event as an info-level log.
+
+    Does **not** close the chat span here: ``_ConversationState`` already
+    closes it on ``UserMessage`` / ``ResultMessage`` boundaries, and racing
+    the close from a hook running in a different anyio task only adds risk
+    for marginal value.
+    """
+    await _run_hook(_record_stop, input_data)
+    return {}
+
+
+async def pre_compact_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Surface upcoming context-window compaction as a warn-level log.
+
+    Compaction is the strongest leading signal of context pressure on long
+    sessions; warn level keeps it filterable in dashboards without being
+    treated as an error.
+    """
+    await _run_hook(_record_pre_compact, input_data)
+    return {}
+
+
+async def notification_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Surface CLI-emitted notifications as info-level logs."""
+    await _run_hook(_record_notification, input_data)
+    return {}
+
+
+async def permission_request_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Surface tool-permission *requests* (the ask, not the outcome) as info-level logs.
+
+    The corresponding *outcome* path — ``PermissionResultDeny`` from the
+    ``can_use_tool`` callback and ``PreToolUse.updatedInput`` mutations —
+    is the territory of issue #10, not this hook. See the recon comment
+    on issue #9 for the boundary rationale.
+    """
+    await _run_hook(_record_permission_request, input_data)
+    return {}
+
+
+# ---------------------------------------------------------------------------
 # Instrumentation entry point.
 # ---------------------------------------------------------------------------
 
@@ -563,11 +697,22 @@ def _inject_tracing_hooks(options: Any) -> None:
             return
         options._logfire_hooks_injected = True
 
-        for event in ('PreToolUse', 'PostToolUse', 'PostToolUseFailure'):
+        # Tool-lifecycle hooks (existing) + non-tool-lifecycle hooks (issue #9).
+        # The non-tool-lifecycle callbacks emit logfire log records under the
+        # active ``invoke_agent`` span; they don't open child spans.
+        events_to_callbacks: tuple[tuple[str, Any], ...] = (
+            ('PreToolUse', pre_tool_use_hook),
+            ('PostToolUse', post_tool_use_hook),
+            ('PostToolUseFailure', post_tool_use_failure_hook),
+            ('UserPromptSubmit', user_prompt_submit_hook),
+            ('Stop', stop_hook),
+            ('PreCompact', pre_compact_hook),
+            ('Notification', notification_hook),
+            ('PermissionRequest', permission_request_hook),
+        )
+        for event, callback in events_to_callbacks:
             hooks.setdefault(event, [])
-        hooks['PreToolUse'].insert(0, HookMatcher(matcher=None, hooks=[pre_tool_use_hook]))
-        hooks['PostToolUse'].insert(0, HookMatcher(matcher=None, hooks=[post_tool_use_hook]))
-        hooks['PostToolUseFailure'].insert(0, HookMatcher(matcher=None, hooks=[post_tool_use_failure_hook]))
+            hooks[event].insert(0, HookMatcher(matcher=None, hooks=[callback]))
 
 
 class _ConversationState:
@@ -596,6 +741,12 @@ class _ConversationState:
         self._current_output_parts: list[MessagePart] = []
         self._system_instructions = system_instructions
         self.model: str | None = None
+        # Hook-event counters (issue #9). Surfaced on the root span at
+        # ``close()`` so dashboards can group by session-level activity.
+        self.user_prompt_count = 0
+        self.compact_count = 0
+        self.notification_count = 0
+        self.permission_request_count = 0
 
     def add_tool_result(self, tool_use_id: str, tool_name: str, result: Any) -> None:
         """Record a tool result to include in the next chat span's input messages."""
@@ -720,6 +871,17 @@ class _ConversationState:
                     CLAUDE_TOOLS_USED,
                     [{'tool': n, 'count': c} for n, c in tool_counts.items()],
                 )
+        # Hook-event counters: emit only the non-zero ones so happy-path
+        # spans don't carry always-zero attributes.
+        counter_map: tuple[tuple[int, str], ...] = (
+            (self.user_prompt_count, CLAUDE_USER_PROMPT_COUNT),
+            (self.compact_count, CLAUDE_COMPACT_COUNT),
+            (self.notification_count, CLAUDE_NOTIFICATION_COUNT),
+            (self.permission_request_count, CLAUDE_PERMISSION_REQUEST_COUNT),
+        )
+        for value, attr in counter_map:
+            if value:
+                self.root_span.set_attribute(attr, value)
         for span in self.active_tool_spans.values():
             span._end()  # pyright: ignore[reportPrivateUsage]
         self.active_tool_spans.clear()
@@ -841,3 +1003,139 @@ def _record_result(span: LogfireSpan, msg: ResultMessage) -> None:
     is_error = getattr(msg, 'is_error', None)
     if is_error:
         span.set_level('error')
+
+
+# ---------------------------------------------------------------------------
+# Hook-event emission helpers (issue #9). Each emits a level-appropriate
+# logfire log under the active ``invoke_agent`` span — mirroring the
+# precedent set by ``_record_rate_limit_event`` / ``_record_mirror_error``.
+# Counters live on ``_ConversationState`` and are surfaced on the root span
+# when the conversation closes.
+# ---------------------------------------------------------------------------
+
+
+def _hook_session_id(input_data: Any) -> dict[str, Any]:
+    """Pull ``session_id`` from a hook input dict, mapped to the OTel semconv
+    ``gen_ai.conversation.id``. Returns ``{}`` when absent so callers can
+    splat it into a log call unconditionally.
+    """
+    sid = (input_data or {}).get('session_id') if isinstance(input_data, dict) else None
+    return {CONVERSATION_ID: sid} if sid else {}
+
+
+def _record_user_prompt_submit(state: _ConversationState, input_data: Any) -> None:
+    """Record a UserPromptSubmit hook event as an info log under the root span.
+
+    ``claude.user_prompt`` is intentionally NOT on the scrubber's SAFE_KEYS:
+    user-typed prompts may contain credentials and default value-level
+    redaction is the safer privacy posture. Operators who want raw prompts
+    can use a ``scrubbing_callback``.
+    """
+    state.user_prompt_count += 1
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    prompt = input_data.get('prompt')
+    attrs: dict[str, Any] = {**_hook_session_id(input_data)}
+    if prompt is not None:
+        attrs[CLAUDE_USER_PROMPT] = prompt
+    state.logfire.info('Hook: UserPromptSubmit', **attrs)
+
+
+def _record_stop(state: _ConversationState, input_data: Any) -> None:
+    """Record a Stop hook event as an info log under the root span.
+
+    Captures ``last_assistant_message`` defensively via ``.get()`` —
+    the field is on the CLI wire format but absent from the SDK's
+    ``StopHookInput`` type, so older SDKs (or future renames) silently
+    skip the attribute. Goes through the scrubber's SAFE_KEYS allowlist
+    because it's model-generated text (mirrors ``claude.result.text``).
+    """
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    attrs: dict[str, Any] = {**_hook_session_id(input_data)}
+    # Emit ``stop_hook_active`` only when True — almost always False.
+    if input_data.get('stop_hook_active'):
+        attrs[CLAUDE_STOP_HOOK_ACTIVE] = True
+    last = input_data.get('last_assistant_message')
+    if last is not None:
+        attrs[CLAUDE_STOP_LAST_ASSISTANT_MESSAGE] = last
+    state.logfire.info('Hook: Stop', **attrs)
+
+
+def _record_pre_compact(state: _ConversationState, input_data: Any) -> None:
+    """Record a PreCompact hook event as a warn log under the root span.
+
+    Compaction is the strongest leading indicator that the session is
+    approaching context limits; warn level keeps it filterable / alertable
+    without being treated as a hard error.
+    """
+    state.compact_count += 1
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    attrs: dict[str, Any] = {**_hook_session_id(input_data)}
+    if (trigger := input_data.get('trigger')) is not None:
+        attrs[CLAUDE_COMPACT_TRIGGER] = trigger
+    if (instructions := input_data.get('custom_instructions')) is not None:
+        attrs[CLAUDE_COMPACT_INSTRUCTIONS] = instructions
+    state.logfire.warn('Hook: PreCompact ({trigger})', trigger=attrs.get(CLAUDE_COMPACT_TRIGGER, ''), **attrs)
+
+
+def _record_notification(state: _ConversationState, input_data: Any) -> None:
+    """Record a Notification hook event as an info log under the root span.
+
+    ``claude.notification.message`` is NOT on SAFE_KEYS: CLI-emitted text
+    can contain paths/words triggering false-positive scrubbing, and
+    accepting that is preferable to allowlisting CLI-controlled content
+    that may evolve.
+    """
+    state.notification_count += 1
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    attrs: dict[str, Any] = {**_hook_session_id(input_data)}
+    field_map: tuple[tuple[str, str], ...] = (
+        ('message', CLAUDE_NOTIFICATION_MESSAGE),
+        ('title', CLAUDE_NOTIFICATION_TITLE),
+        ('notification_type', CLAUDE_NOTIFICATION_TYPE),
+    )
+    for sdk_field, attr_name in field_map:
+        if (value := input_data.get(sdk_field)) is not None:
+            attrs[attr_name] = value
+    state.logfire.info(
+        'Hook: Notification ({notification_type})',
+        notification_type=attrs.get(CLAUDE_NOTIFICATION_TYPE, ''),
+        **attrs,
+    )
+
+
+def _record_permission_request(state: _ConversationState, input_data: Any) -> None:
+    """Record a PermissionRequest hook event as an info-level audit log.
+
+    Captures ``agent_id`` / ``agent_type`` opportunistically when the
+    request originates inside a subagent context (groundwork for #3).
+    ``permission_suggestions`` shape is uncertain (``list[Any]``) — capture
+    when truthy without imposing a sub-schema we'd have to break later.
+    ``tool_input`` is caller-supplied arbitrary user data — deliberately
+    NOT on SAFE_KEYS, matching the ``claude.permission_denials`` precedent.
+    """
+    state.permission_request_count += 1
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    attrs: dict[str, Any] = {**_hook_session_id(input_data)}
+    field_map: tuple[tuple[str, str], ...] = (
+        ('tool_name', TOOL_NAME),
+        ('tool_input', CLAUDE_PERMISSION_REQUEST_TOOL_INPUT),
+        ('agent_id', CLAUDE_AGENT_ID),
+        ('agent_type', CLAUDE_AGENT_TYPE),
+    )
+    for sdk_field, attr_name in field_map:
+        if (value := input_data.get(sdk_field)) is not None:
+            attrs[attr_name] = value
+    # ``permission_suggestions`` shape is uncertain (``list[Any]``) — capture
+    # only when truthy so we don't emit empty lists.
+    if suggestions := input_data.get('permission_suggestions'):
+        attrs[CLAUDE_PERMISSION_REQUEST_SUGGESTIONS] = suggestions
+    state.logfire.info(
+        'Hook: PermissionRequest ({tool_name})',
+        tool_name=attrs.get(TOOL_NAME, ''),
+        **attrs,
+    )

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -171,6 +171,45 @@ CLAUDE_ENABLE_FILE_CHECKPOINTING = 'claude.enable_file_checkpointing'
 CLAUDE_RESUME_FROM = 'claude.resume_from'
 CLAUDE_FORK_ON_RESUME = 'claude.fork_on_resume'
 
+# Hook-event attributes (issue #9). Each non-tool-lifecycle hook that the
+# Claude Agent SDK fires (UserPromptSubmit / Stop / PreCompact / Notification
+# / PermissionRequest) emits a level-appropriate logfire log under the
+# active ``invoke_agent`` span. Cumulative counts are aggregated on the
+# root span at conversation close (mirroring ``claude.tools_used``).
+#
+# Naming: counter attrs use a bare ``_count`` suffix (``claude.compact_count``)
+# rather than nesting under the per-event sub-namespace (``claude.compact.count``)
+# — they are root-span session aggregates, analogous to ``claude.tools_used``,
+# not per-event detail attributes. Don't "fix" this asymmetry without
+# updating the dashboards that key on these names.
+#
+# SAFE_KEYS additions: ``claude.compact.custom_instructions`` and
+# ``claude.stop.last_assistant_message`` carry model-generated /
+# operator-set text that default regex scrubbing would over-redact;
+# ``claude.user_prompt`` deliberately stays subject to scrubbing because
+# user-typed prompts may contain credentials. See scrubbing.py for the
+# exact allowlist.
+CLAUDE_USER_PROMPT = 'claude.user_prompt'
+CLAUDE_USER_PROMPT_COUNT = 'claude.user_prompt_count'
+CLAUDE_STOP_HOOK_ACTIVE = 'claude.stop.hook_active'
+# ``last_assistant_message`` is on the wire but not in the SDK's StopHookInput
+# type; capture defensively via .get().
+CLAUDE_STOP_LAST_ASSISTANT_MESSAGE = 'claude.stop.last_assistant_message'
+CLAUDE_COMPACT_TRIGGER = 'claude.compact.trigger'
+CLAUDE_COMPACT_INSTRUCTIONS = 'claude.compact.custom_instructions'
+CLAUDE_COMPACT_COUNT = 'claude.compact_count'
+CLAUDE_NOTIFICATION_MESSAGE = 'claude.notification.message'
+CLAUDE_NOTIFICATION_TITLE = 'claude.notification.title'
+CLAUDE_NOTIFICATION_TYPE = 'claude.notification.type'
+CLAUDE_NOTIFICATION_COUNT = 'claude.notification_count'
+CLAUDE_PERMISSION_REQUEST_TOOL_INPUT = 'claude.permission_request.tool_input'
+CLAUDE_PERMISSION_REQUEST_SUGGESTIONS = 'claude.permission_request.suggestions'
+CLAUDE_PERMISSION_REQUEST_COUNT = 'claude.permission_request_count'
+# Subagent attribution (also surfaced from PermissionRequest hooks fired
+# inside a subagent context — groundwork for issue #3).
+CLAUDE_AGENT_ID = 'claude.agent_id'
+CLAUDE_AGENT_TYPE = 'claude.agent_type'
+
 # Type definitions for message parts and messages
 
 

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -178,6 +178,12 @@ class BaseScrubber(ABC):
         gen_ai_semconv.CLAUDE_RESULT_SUBTYPE,
         gen_ai_semconv.CLAUDE_MODEL_USAGE,
         gen_ai_semconv.CLAUDE_TOOLS_USED,
+        # Hook-event content (issue #9). Operator-set or model-generated
+        # text that default regex scrubbing would over-redact. See semconv.py
+        # for the rationale; ``claude.user_prompt`` and
+        # ``claude.notification.*`` are deliberately *not* on this list.
+        gen_ai_semconv.CLAUDE_COMPACT_INSTRUCTIONS,
+        gen_ai_semconv.CLAUDE_STOP_LAST_ASSISTANT_MESSAGE,
     }
 
     @abstractmethod

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -51,12 +51,22 @@ from logfire._internal.integrations.claude_agent_sdk import (
     _inject_tracing_hooks,
     _options_attrs,
     _record_mirror_error,
+    _record_notification,
+    _record_permission_request,
+    _record_pre_compact,
     _record_rate_limit_event,
     _record_result,
+    _record_stop,
+    _record_user_prompt_submit,
     _set_state,
+    notification_hook,
+    permission_request_hook,
     post_tool_use_failure_hook,
     post_tool_use_hook,
+    pre_compact_hook,
     pre_tool_use_hook,
+    stop_hook,
+    user_prompt_submit_hook,
 )
 from logfire.testing import TestExporter
 
@@ -985,11 +995,30 @@ def test_inject_hooks_no_hooks_attr() -> None:
 
 
 def test_inject_hooks_none_hooks() -> None:
+    """All 8 hook events register a callback when injection runs.
+
+    Locks the full coverage contract: tool-lifecycle (PreToolUse / PostToolUse
+    / PostToolUseFailure) plus the 5 non-tool-lifecycle hooks added in #9
+    (UserPromptSubmit / Stop / PreCompact / Notification / PermissionRequest).
+    A regression that drops one event silently kills observability for that
+    event class — the test is the gate.
+    """
     options = ClaudeAgentOptions(hooks=None)
     _inject_tracing_hooks(options)
     assert options.hooks is not None
-    assert 'PreToolUse' in options.hooks
-    assert len(options.hooks['PreToolUse']) == 1
+    expected_events = {
+        'PreToolUse',
+        'PostToolUse',
+        'PostToolUseFailure',
+        'UserPromptSubmit',
+        'Stop',
+        'PreCompact',
+        'Notification',
+        'PermissionRequest',
+    }
+    assert set(options.hooks) == expected_events
+    for event in expected_events:
+        assert len(options.hooks[event]) == 1, f'event {event!r} should have exactly one matcher'
 
 
 def test_inject_hooks_with_existing_events() -> None:
@@ -1005,8 +1034,302 @@ def test_inject_hooks_with_existing_events() -> None:
     options = Opts()
     _inject_tracing_hooks(options)
     assert options.hooks is not None
+    # Existing user-supplied matcher is preserved AFTER our injected one
+    # (we ``insert(0, ...)`` so our hook runs first).
     assert len(options.hooks['PreToolUse']) == 2
     assert options.hooks['PreToolUse'][1] is existing_hook
+    # New non-tool-lifecycle events are added too, even though Opts didn't
+    # declare them.
+    for event in ('UserPromptSubmit', 'Stop', 'PreCompact', 'Notification', 'PermissionRequest'):
+        assert event in options.hooks
+        assert len(options.hooks[event]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Hook-event helper tests (issue #9). Each helper is a small unit that runs
+# under an open ``invoke_agent`` span; we drive it directly with synthetic
+# input dicts rather than going through the SDK's hook-dispatch machinery.
+# Three of the five hooks (PreCompact / Notification / PermissionRequest)
+# don't fire under non-interactive SDK transport — these unit tests are the
+# only coverage they get, so the assertions are intentionally specific
+# (level, attribute names, scrubber-relevance, counter behavior).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_record_user_prompt_submit_emits_log_with_prompt_attr(exporter: TestExporter) -> None:
+    """``_record_user_prompt_submit`` emits an info log under the active
+    invoke_agent with ``claude.user_prompt`` carrying the submitted text and
+    increments the per-conversation counter.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_user_prompt_submit(state, {'session_id': 's1', 'prompt': 'hello world'})
+    assert state.user_prompt_count == 1
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Hook: UserPromptSubmit')
+    assert log['attributes']['claude.user_prompt'] == 'hello world'
+    assert log['attributes']['gen_ai.conversation.id'] == 's1'
+    assert log['attributes']['logfire.level_num'] == 9  # info
+
+
+@pytest.mark.anyio
+async def test_record_user_prompt_submit_skips_when_prompt_absent(exporter: TestExporter) -> None:
+    """A defensive run with no ``prompt`` field still increments the counter
+    and emits the log (audit value: every hook fires, even malformed ones)
+    but skips the ``claude.user_prompt`` attribute."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_user_prompt_submit(state, {'session_id': 's1'})
+    assert state.user_prompt_count == 1
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Hook: UserPromptSubmit')
+    assert 'claude.user_prompt' not in log['attributes']
+
+
+@pytest.mark.anyio
+async def test_record_stop_captures_undeclared_last_assistant_message(exporter: TestExporter) -> None:
+    """``last_assistant_message`` is on the wire but absent from the SDK's
+    ``StopHookInput`` type. Capturing it via ``.get()`` is the forward-compat
+    contract: present today → land it; absent tomorrow → silently skip.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_stop(
+            state,
+            {'session_id': 's1', 'stop_hook_active': False, 'last_assistant_message': 'final text'},
+        )
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Hook: Stop')
+    assert log['attributes']['claude.stop.last_assistant_message'] == 'final text'
+    # ``stop_hook_active=False`` is the common case — skip it to keep
+    # happy-path logs noise-free.
+    assert 'claude.stop.hook_active' not in log['attributes']
+
+
+@pytest.mark.anyio
+async def test_record_stop_emits_hook_active_only_when_true(exporter: TestExporter) -> None:
+    """Locks the "emit only when True" semantic for ``stop_hook_active``.
+
+    If the SDK ever flips this to default-True the logs would otherwise be
+    drowned in always-True attrs; the test is the canary.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_stop(state, {'session_id': 's1', 'stop_hook_active': True})
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Hook: Stop')
+    assert log['attributes']['claude.stop.hook_active'] is True
+
+
+@pytest.mark.anyio
+async def test_record_pre_compact_emits_warn_log_with_trigger(exporter: TestExporter) -> None:
+    """PreCompact is warn-level (context-pressure signal) and increments
+    ``compact_count``. Captures both ``trigger`` and ``custom_instructions``.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_pre_compact(
+            state,
+            {'session_id': 's1', 'trigger': 'auto', 'custom_instructions': 'preserve API tokens section'},
+        )
+    assert state.compact_count == 1
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'].startswith('Hook: PreCompact'))
+    assert log['attributes']['claude.compact.trigger'] == 'auto'
+    assert log['attributes']['claude.compact.custom_instructions'] == 'preserve API tokens section'
+    assert log['attributes']['logfire.level_num'] == 13  # warn
+
+
+@pytest.mark.anyio
+async def test_record_pre_compact_skips_none_custom_instructions(exporter: TestExporter) -> None:
+    """``custom_instructions`` is ``str | None`` per the SDK type — None → skip."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_pre_compact(
+            state,
+            {'session_id': 's1', 'trigger': 'manual', 'custom_instructions': None},
+        )
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'].startswith('Hook: PreCompact'))
+    assert 'claude.compact.custom_instructions' not in log['attributes']
+    assert log['attributes']['claude.compact.trigger'] == 'manual'
+
+
+@pytest.mark.anyio
+async def test_record_notification_captures_message_title_type(exporter: TestExporter) -> None:
+    """Notification hook surfaces all 3 SDK fields plus the per-conversation counter."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_notification(
+            state,
+            {
+                'session_id': 's1',
+                'message': 'Permission needed',
+                'title': 'Claude Code',
+                'notification_type': 'permission_request',
+            },
+        )
+    assert state.notification_count == 1
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'].startswith('Hook: Notification'))
+    assert log['attributes']['claude.notification.message'] == 'Permission needed'
+    assert log['attributes']['claude.notification.title'] == 'Claude Code'
+    assert log['attributes']['claude.notification.type'] == 'permission_request'
+
+
+@pytest.mark.anyio
+async def test_record_permission_request_captures_subagent_attribution(exporter: TestExporter) -> None:
+    """PermissionRequest fired from inside a subagent context — capture
+    ``agent_id`` / ``agent_type`` opportunistically (groundwork for #3).
+    Also locks ``tool_input`` capture under the audit attr.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_permission_request(
+            state,
+            {
+                'session_id': 's1',
+                'tool_name': 'Bash',
+                'tool_input': {'command': 'rm -rf tmp/'},
+                'permission_suggestions': [{'allow': True}],
+                'agent_id': 'subagent-7',
+                'agent_type': 'general-purpose',
+            },
+        )
+    assert state.permission_request_count == 1
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'].startswith('Hook: PermissionRequest'))
+    assert log['attributes']['gen_ai.tool.name'] == 'Bash'
+    assert log['attributes']['claude.permission_request.tool_input'] == {'command': 'rm -rf tmp/'}
+    assert log['attributes']['claude.permission_request.suggestions'] == [{'allow': True}]
+    assert log['attributes']['claude.agent_id'] == 'subagent-7'
+    assert log['attributes']['claude.agent_type'] == 'general-purpose'
+
+
+@pytest.mark.anyio
+async def test_record_permission_request_skips_subagent_attribution_when_absent(exporter: TestExporter) -> None:
+    """Main-thread PermissionRequest (no subagent context) → no agent.* attrs."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_permission_request(
+            state,
+            {'session_id': 's1', 'tool_name': 'Read', 'tool_input': {'path': '/tmp/foo'}},
+        )
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'].startswith('Hook: PermissionRequest'))
+    for absent in ('claude.agent_id', 'claude.agent_type', 'claude.permission_request.suggestions'):
+        assert absent not in log['attributes'], f'{absent!r} should be skipped when not in input'
+
+
+@pytest.mark.anyio
+async def test_close_emits_hook_event_counters_when_nonzero(exporter: TestExporter) -> None:
+    """Counters land on the ``invoke_agent`` root span at ``close()`` —
+    matches the ``claude.tools_used`` precedent. Regressions that fail to
+    set them on the root would silently break dashboard aggregation.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        # Fire each helper so all four counters increment.
+        _record_user_prompt_submit(state, {'session_id': 's1', 'prompt': 'p'})
+        _record_pre_compact(state, {'session_id': 's1', 'trigger': 'auto', 'custom_instructions': None})
+        _record_notification(state, {'session_id': 's1', 'message': 'm', 'notification_type': 'idle'})
+        _record_permission_request(state, {'session_id': 's1', 'tool_name': 'Bash', 'tool_input': {}})
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    assert root_attrs['claude.user_prompt_count'] == 1
+    assert root_attrs['claude.compact_count'] == 1
+    assert root_attrs['claude.notification_count'] == 1
+    assert root_attrs['claude.permission_request_count'] == 1
+
+
+@pytest.mark.anyio
+async def test_close_skips_zero_hook_event_counters(exporter: TestExporter) -> None:
+    """Sessions where no hook events fired don't carry zero-valued counter
+    attributes — keeps happy-path spans noise-free.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    for absent in (
+        'claude.user_prompt_count',
+        'claude.compact_count',
+        'claude.notification_count',
+        'claude.permission_request_count',
+    ):
+        assert absent not in root_attrs
+
+
+@pytest.mark.anyio
+async def test_hook_callbacks_no_state_returns_empty() -> None:
+    """All five new hook callbacks bail out gracefully when there is no
+    active ``_ConversationState`` — covers the case where a hook fires
+    outside an instrumented ``receive_response`` block (e.g. SDK initialised
+    but no query in flight).
+    """
+    ctx: HookContext = {'signal': None}
+    _clear_state()
+    for callback in (
+        user_prompt_submit_hook,
+        stop_hook,
+        pre_compact_hook,
+        notification_hook,
+        permission_request_hook,
+    ):
+        assert await callback({'session_id': 's1'}, 'tu_1', ctx) == {}
+
+
+@pytest.mark.anyio
+async def test_hook_callbacks_attach_to_root_span_context(exporter: TestExporter) -> None:
+    """A hook callback fires in a different anyio task → contextvars don't
+    propagate. Each callback explicitly attaches the root span as the active
+    OTel context before emitting, so the resulting log lands as a CHILD of
+    ``invoke_agent``, not as an orphan top-level span.
+
+    Locks the integration's most subtle invariant — a regression that drops
+    the attach/detach dance produces orphan spans that silently break
+    dashboards keyed on root-span filtering.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    ctx: HookContext = {'signal': None}
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            await user_prompt_submit_hook({'session_id': 's1', 'prompt': 'hi'}, 'tu_1', ctx)
+            await stop_hook({'session_id': 's1', 'stop_hook_active': False}, 'tu_2', ctx)
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_span = next(s for s in spans if s['name'] == 'invoke_agent')
+    root_id = root_span['context']['span_id']
+    for log_name in ('Hook: UserPromptSubmit', 'Hook: Stop'):
+        log = next(s for s in spans if s['name'] == log_name)
+        assert log['parent']['span_id'] == root_id, f'{log_name} should be parented to invoke_agent'
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #9. Recon: https://github.com/oneryalcin/logfire/issues/9#issuecomment-4319570151. Empirical addendum: https://github.com/oneryalcin/logfire/issues/9#issuecomment-4319597657.

## Summary

The Claude Agent SDK fires 10 hook events; the integration registered callbacks for only 3 (`PreToolUse` / `PostToolUse` / `PostToolUseFailure`). Five non-tool-lifecycle hooks were silently dropped:

- `UserPromptSubmit` (every `client.query`)
- `Stop` (every end-of-turn)
- `PreCompact` (context compaction — strongest leading signal of context pressure on long sessions)
- `Notification` (CLI-emitted notifications)
- `PermissionRequest` (tool-permission prompts — audit-relevant)

This PR extends `_inject_tracing_hooks` to register all five and adds matching helpers that emit level-appropriate logfire log records under the active `invoke_agent` span (mirroring `_record_rate_limit_event` / `_record_mirror_error` rather than opening child spans). Counters for the four user-affecting events (`claude.user_prompt_count`, `.compact_count`, `.notification_count`, `.permission_request_count`) land on the root span at `close()`.

## Span shape: log records, not child spans

Hook callbacks run in different anyio tasks where contextvars don't propagate, so emitting from inside a hook would orphan the resulting span. Each callback explicitly attaches the root span as the active OTel context (mirroring ``pre_tool_use_hook``'s existing dance) before invoking its `_record_*` helper, so log records nest correctly under `invoke_agent`. The 5 callbacks share a `_run_hook` factored helper (post-simplifier-review) to keep that contract consistent and the boilerplate minimal. **The context-attach invariant is locked by ``test_hook_callbacks_attach_to_root_span_context``** — a regression that drops the dance produces orphan spans and the test fails loudly.

## Privacy / SAFE_KEYS choices

| Attribute | SAFE_KEYS? | Rationale |
|---|---|---|
| ``claude.compact.custom_instructions`` | yes | Operator-set guidance text; mirrors ``claude.result.text`` precedent. |
| ``claude.stop.last_assistant_message`` | yes | Model-generated final-turn text. |
| ``claude.user_prompt`` | **no** | User-typed prompts may contain credentials; default-on regex scrubbing is the safer privacy posture. Deployments needing raw prompts can opt-out per-attribute via ``scrubbing_callback``. |
| ``claude.notification.message`` | **no** | CLI-emitted text content may evolve; allowlisting risks masking future regressions. |
| ``claude.permission_request.tool_input`` | **no** | Mirrors the existing ``claude.permission_denials`` precedent (caller-supplied arbitrary data). |

There's a deliberate **privacy asymmetry**: the assistant's last message is allowlisted while the user's prompt is scrub-eligible. This is the same posture as ``claude.result.text`` (allowlisted) vs ``claude.permission_denials.tool_input`` (scrub-eligible) on the existing path. Documented in the user-facing docs.

## SDK-drift and forward-compat

- ``Stop.last_assistant_message`` is on the wire but absent from the SDK's ``StopHookInput`` type — captured via ``.get()`` so older SDKs and future renames silently skip the attribute.
- ``PermissionRequestHookInput`` inherits ``_SubagentContextMixin``, which provides optional ``agent_id`` / ``agent_type``. Captured opportunistically as ``claude.agent_id`` / ``claude.agent_type`` when present (groundwork for issue #3 subagent stitching).
- ``permission_suggestions`` is ``list[Any]`` in the SDK type — captured as-is when truthy without imposing a sub-schema we'd have to break.
- All five hook callbacks accept ``tool_use_id`` positionally even though the SDK passes a fresh UUID for non-tool events; helpers don't bail on it (only the existing tool-lifecycle callbacks do).

## Span-name / message-template choices

- Message templates use ``Hook: <EventName>`` (e.g. ``Hook: PreCompact (auto)``, ``Hook: PermissionRequest (Bash)``) — a deliberate UX choice for trace readability that visually distinguishes hook-callback events from SDK-generated stream events. Different style from ``rate_limit {status}`` (the existing ``_record_rate_limit_event`` precedent) and worth flagging here.
- Span-name cardinality is bounded by the template (placeholders intact in ``span.name``); the formatted result lives in ``logfire.msg``.
- Cosmetic scrubber side-effect on MCP tools whose name contains ``auth`` (e.g. ``mcp__authgateway__login``): the formatted message string renders as ``Hook: PermissionRequest ([Scrubbed due to 'auth'])``, but ``gen_ai.tool.name`` is in SAFE_KEYS so the attribute value is preserved — dashboards and SQL queries are unaffected. Trade-off worth knowing.

## Coordination boundaries

- **Issue #10** owns the permission *outcome* path (``PermissionResultDeny`` from ``can_use_tool``, ``PreToolUse.updatedInput`` mutations). #9 is the *request* side only.
- **Issue #3** owns subagent span nesting; this PR captures ``agent_id`` / ``agent_type`` opportunistically without opening subagent spans.
- **Issue #12** (``threading.local`` races) is unchanged territory — the new counters live on the same ``_ConversationState`` container as everything else; no new race surface.
- **Issue #22** (filed alongside this work) tracks ``SessionStart`` / ``SessionEnd`` — these are CLI-schema hooks not exposed by the Python SDK, requiring upstream SDK work, not in scope here.

## Empirical verification

``empirical/issue_09_unused_hook_events.py`` registers spy hook callbacks for all 5 events and runs a real ``ClaudeSDKClient`` session against the Anthropic API.

- **Pre-patch baseline**: spies fire for ``UserPromptSubmit`` and ``Stop``; logfire's in-memory exporter shows zero attribute / log records matching any of ``user_prompt`` / ``compact`` / ``notification`` / ``permission_request`` / ``stop_hook_active`` substrings across 6 spans. Baseline confirmed.
- **Post-patch**: ``Hook: UserPromptSubmit`` and ``Hook: Stop`` log records nest under ``invoke_agent`` with all documented attrs (``claude.user_prompt``, ``claude.stop.last_assistant_message``, ``gen_ai.conversation.id``); ``claude.user_prompt_count = 1`` lands on the root.
- ``PreCompact``, ``Notification``, and ``PermissionRequest`` don't fire under non-interactive SDK transport (interactive-TTY-gated); covered by focused unit tests instead.

Logfire UI trace at ``service=issue-09-unused-hook-events`` (``discovering-cc`` project).

## Tests

15 new tests in ``test_claude_agent_sdk.py``:

- Per-helper assertions for each emission shape (level, attribute names, scrubber-relevance, counter increment).
- ``claude.stop.last_assistant_message`` capture lock against SDK type drift; ``claude.stop.hook_active`` emit-only-when-True semantic lock.
- ``claude.permission_request.*`` with and without subagent attribution.
- Counter aggregation on root at ``close()`` + zero-counter skip semantic.
- Hook-callback no-state graceful return for all 5 callbacks.
- Context-attach invariant lock (``test_hook_callbacks_attach_to_root_span_context``).

Updated ``test_inject_hooks_none_hooks`` / ``test_inject_hooks_with_existing_events`` to assert all 8 events register a callback (full SDK-supported coverage is now 8 of 10; remaining 2 are subagent hooks owned by #3).

Cassette test snapshot unchanged — ``fake_claude.py`` replays the message stream but doesn't drive the SDK's hook control protocol, so the new callbacks correctly don't fire there.

## Adversarial review

Three reviewers in parallel before commit:

- **Opus (P0/P1)**: no blockers. Empirically probed all 16 new attribute names against the default scrubber regex — zero triggers. Verified SAFE_KEYS additions correctly preserve only model-output / operator-set fields. Five P2 advisories all considered: keeping warn level on PreCompact (deliberate UX), the formatted-message cosmetic scrub for MCP tool names containing ``auth`` (attribute preserved via SAFE_KEY), counter-before-validation intentional, attach/detach coverage shared via ``_run_hook`` is sufficient, privacy asymmetry surfaced in user-facing docs.
- **Sonnet (pattern compliance)**: clean except for docs (addressed in this PR) and a one-line semconv comment explaining the bare ``_count`` suffix asymmetry (addressed). All other compliance points verified clean.
- **code-simplifier (collapse-only)**: factored 5×12-line callback bodies through one ``_run_hook`` helper; folded 4 None-checks in ``_record_permission_request`` through a ``field_map`` matching the existing ``rate_limit`` precedent. ``-27`` net lines. All tests still green.

## Test plan

- [x] ``49 passed, 1 deselected`` (the pre-existing ``test_tool_use_conversation_cassette`` flake on ``main``).
- [x] ``test_secret_scrubbing`` — 12 passed (no regression from SAFE_KEYS additions).
- [x] ``test_logfire_api`` — 3 passed, 1 skipped (no public-API change).
- [x] Empirical end-to-end through real Anthropic API + logfire UI: live trace shows ``Hook: UserPromptSubmit`` and ``Hook: Stop`` nested under ``invoke_agent`` with all documented attrs and counters.