### PR TITLE
Trace ClaudeSDKClient lifecycle, control methods, and receive_messages

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -110,6 +110,26 @@ The `Hook:` prefix is a deliberate UX choice for trace readability — it makes 
 
 `PreToolUse` hooks can return `updatedInput` to mutate a tool's arguments before execution; the same applies to `can_use_tool`'s `PermissionResultAllow.updated_input`. When this happens between `pre_tool_use_hook` and execution, the integration overwrites `gen_ai.tool.call.arguments` on the `execute_tool` span with the executed (post-mutation) value — matching the OTel Gen AI semconv expectation that `arguments` reflects what the tool actually saw — and surfaces the original (pre-hook) value under `claude.tool_call.arguments.original`. The diff attribute is absent on the common path where no hook mutated the input, so happy-path spans stay noise-free. Both attributes carry caller-supplied data and remain subject to the default scrubber.
 
+## Lifecycle and control-method spans
+
+`ClaudeSDKClient`'s lifecycle entry/exit and mid-session control methods are wrapped in spans so startup latency, model switches, and MCP toggles are visible — none of these were traced before:
+
+- **`connect`** — spans the CLI subprocess launch and `Query.initialize` handshake. Carries `claude.cli_path` when set in `ClaudeAgentOptions`. On `CLINotFoundError` / `CLIConnectionError` / `ProcessError`, the span is escalated to error level with `error.type` (short class name) and, for `ProcessError` specifically, `claude.process.exit_code` and `claude.process.stderr` (truncated to the first 200 characters). Logfire's automatic exception recording also attaches the full traceback under `exception_type` / `exception.stacktrace` separately, so the audit trail is complete.
+- **`disconnect`** — spans subprocess teardown. The SDK's `connect()` calls `disconnect()` from its own except cleanup on failure; that nested invocation produces a child `disconnect` span under the failed `connect`.
+- **`set_model`** — captures the requested model under `gen_ai.request.model`. Mid-session model switches were previously invisible, breaking cost attribution when the active model differed from `ClaudeAgentOptions.model`. The attribute is absent when `set_model(None)` is called to revert to the default.
+- **`set_permission_mode`** — captures the new mode under `claude.permission_mode` (the same attribute name used by the options-side capture from #8).
+- **`rewind_files`** — captures `claude.rewind.user_message_id`.
+- **`stop_task`** — captures `claude.task_id`.
+- **`interrupt`** — timing only, no input attributes.
+- **`mcp.reconnect`** / **`mcp.toggle`** — both carry `claude.mcp.server_name`; `mcp.toggle` additionally carries `claude.mcp.enabled`. The `mcp.` prefix groups MCP sub-domain operations distinctly from session-lifecycle calls in dashboards.
+
+These spans are top-level (no `invoke_agent` parent) when called between turns; if a control method is invoked from inside an active `receive_response` / `receive_messages` iteration (e.g. from a hook callback), it nests under the active `invoke_agent` via the existing thread-local OTel context.
+
+`receive_messages` (the alternate iterator to `receive_response`) now produces the same `invoke_agent` / `chat` / `Hook: *` span tree as `receive_response`. Sessions using `receive_messages` were previously a complete observability black hole; the integration internally factors a shared lifecycle so both iterators produce identical traces.
+
+!!! note "`receive_messages` and the break-without-aclose edge case"
+    `receive_messages` has no auto-stop sentinel, so the user must `break` to leave the loop. If the loop breaks without explicitly calling `await iter.aclose()` or using `async with closing(...)`, Python may not run the wrapper's `finally` block immediately — the OTel context for `invoke_agent` stays active until garbage collection runs, and any operations called between break and aclose (including `__aexit__`'s implicit `disconnect`) will parent to the stale `invoke_agent`. Doesn't affect `receive_response` (which auto-stops cleanly at `ResultMessage`). For `receive_messages`, prefer `async with contextlib.aclosing(client.receive_messages()) as it: ...` if you break early.
+
 ## End-of-conversation result fields
 
 The `invoke_agent` span carries the conversation-level summary extracted from `ResultMessage`:

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -36,6 +36,7 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_AGENT_TYPE,
     CLAUDE_AGENTS,
     CLAUDE_ALLOWED_TOOLS,
+    CLAUDE_CLI_PATH,
     CLAUDE_COMPACT_COUNT,
     CLAUDE_COMPACT_INSTRUCTIONS,
     CLAUDE_COMPACT_TRIGGER,
@@ -48,6 +49,8 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_INCLUDE_PARTIAL_MESSAGES,
     CLAUDE_MAX_BUDGET_USD,
     CLAUDE_MAX_TURNS,
+    CLAUDE_MCP_ENABLED,
+    CLAUDE_MCP_SERVER_NAME,
     CLAUDE_MESSAGE_UUID,
     CLAUDE_MODEL_USAGE,
     CLAUDE_NOTIFICATION_COUNT,
@@ -67,16 +70,20 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_PERMISSION_RESULT_MESSAGE,
     CLAUDE_PERMISSION_RESULT_UPDATED_INPUT,
     CLAUDE_PERMISSION_RESULT_UPDATED_PERMISSIONS,
+    CLAUDE_PROCESS_EXIT_CODE,
+    CLAUDE_PROCESS_STDERR,
     CLAUDE_RESULT_ERRORS,
     CLAUDE_RESULT_STRUCTURED_OUTPUT,
     CLAUDE_RESULT_SUBTYPE,
     CLAUDE_RESULT_TEXT,
     CLAUDE_RESUME_FROM,
+    CLAUDE_REWIND_USER_MESSAGE_ID,
     CLAUDE_SETTING_SOURCES,
     CLAUDE_SKILLS,
     CLAUDE_SKILLS_MODE,
     CLAUDE_STOP_HOOK_ACTIVE,
     CLAUDE_STOP_LAST_ASSISTANT_MESSAGE,
+    CLAUDE_TASK_ID,
     CLAUDE_TOOL_CALL_ARGUMENTS_ORIGINAL,
     CLAUDE_TOOLS_USED,
     CLAUDE_USER_PROMPT,
@@ -619,6 +626,19 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
     original_init = cls.__init__
     original_query = cls.query
     original_receive_response = cls.receive_response
+    # Issue #11 — methods we may or may not be able to patch depending on the
+    # installed SDK version. ``getattr(... , None)`` so older SDKs without one
+    # of these methods don't crash on import; we just skip the patch.
+    original_receive_messages = getattr(cls, 'receive_messages', None)
+    original_connect = getattr(cls, 'connect', None)
+    original_disconnect = getattr(cls, 'disconnect', None)
+    original_interrupt = getattr(cls, 'interrupt', None)
+    original_set_permission_mode = getattr(cls, 'set_permission_mode', None)
+    original_set_model = getattr(cls, 'set_model', None)
+    original_rewind_files = getattr(cls, 'rewind_files', None)
+    original_reconnect_mcp_server = getattr(cls, 'reconnect_mcp_server', None)
+    original_toggle_mcp_server = getattr(cls, 'toggle_mcp_server', None)
+    original_stop_task = getattr(cls, 'stop_task', None)
 
     cls._is_instrumented_by_logfire = True  # pyright: ignore[reportAttributeAccessIssue]
 
@@ -651,9 +671,21 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
 
     cls.query = patched_query
 
-    # --- Patch receive_response ---
-    @functools.wraps(original_receive_response)
-    async def patched_receive_response(self: Any) -> AsyncGenerator[Any, None]:
+    # --- Shared body for receive_response / receive_messages ---
+    # Both iterators open the same ``invoke_agent`` lifecycle and run the
+    # same message-dispatch loop. Factored so issue #11 can patch
+    # ``receive_messages`` without copy-pasting the entire body — the
+    # alternate iterator was previously a complete observability black hole.
+    async def _drive_invoke_agent(self: Any, source_iter: Any) -> AsyncGenerator[Any, None]:
+        # ``receive_response`` calls ``self.receive_messages()`` internally
+        # (see SDK ``client.py:566-580``). When both are patched, the inner
+        # call would open a nested ``invoke_agent`` span — wrong. Detect the
+        # nesting here and delegate without re-wrapping if state is already set.
+        if _get_state() is not None:
+            async for msg in source_iter:
+                yield msg
+            return
+
         prompt = getattr(self, '_logfire_prompt', None)
         input_messages: list[ChatMessage] = []
         if prompt:  # pragma: no branch
@@ -688,7 +720,7 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
             state.open_chat_span()
 
             try:
-                async for msg in original_receive_response(self):
+                async for msg in source_iter:
                     with handle_internal_errors:
                         if isinstance(msg, AssistantMessage):
                             state.handle_assistant_message(msg)
@@ -709,19 +741,197 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                 state.close()
                 _clear_state()
 
+    # --- Patch receive_response ---
+    @functools.wraps(original_receive_response)
+    async def patched_receive_response(self: Any) -> AsyncGenerator[Any, None]:
+        async for msg in _drive_invoke_agent(self, original_receive_response(self)):
+            yield msg
+
     cls.receive_response = patched_receive_response
+
+    # --- Patch receive_messages (issue #11) ---
+    # Without this, sessions using ``receive_messages`` instead of
+    # ``receive_response`` produce ZERO logfire spans — empirically confirmed
+    # in issue #11's baseline harness.
+    if original_receive_messages is not None:
+
+        @functools.wraps(original_receive_messages)
+        async def patched_receive_messages(self: Any) -> AsyncGenerator[Any, None]:
+            async for msg in _drive_invoke_agent(self, original_receive_messages(self)):
+                yield msg
+
+        cls.receive_messages = patched_receive_messages
+    else:  # pragma: no cover
+        patched_receive_messages = None
+
+    # --- Patch connect / disconnect (issue #11) ---
+    # Lifecycle spans capture CLI-startup latency (a real tail-latency
+    # contributor) and surface ``CLINotFoundError`` / ``ProcessError`` /
+    # ``CLIConnectionError`` that today vanish silently into user code.
+    if original_connect is not None:
+
+        @functools.wraps(original_connect)
+        async def patched_connect(self: Any, *args: Any, **kwargs: Any) -> Any:
+            attrs: dict[str, Any] = {}
+            cli_path = getattr(getattr(self, 'options', None), 'cli_path', None)
+            if cli_path is not None:
+                attrs[CLAUDE_CLI_PATH] = str(cli_path)
+            with _traced_span(logfire_claude, 'connect', **attrs):
+                return await original_connect(self, *args, **kwargs)
+
+        cls.connect = patched_connect
+
+    if original_disconnect is not None:
+
+        @functools.wraps(original_disconnect)
+        async def patched_disconnect(self: Any, *args: Any, **kwargs: Any) -> Any:
+            with _traced_span(logfire_claude, 'disconnect'):
+                return await original_disconnect(self, *args, **kwargs)
+
+        cls.disconnect = patched_disconnect
+
+    # --- Patch control methods (issue #11) ---
+    # All control methods share the same shape: open a short span, capture
+    # the relevant input under a claude.* attr, await the original, surface
+    # any error. Generated via a small factory so each patch is one line of
+    # configuration rather than a copy-paste block.
+    control_method_specs: tuple[tuple[str, Any, str | None], ...] = (
+        ('interrupt', original_interrupt, None),
+        ('set_permission_mode', original_set_permission_mode, CLAUDE_PERMISSION_MODE),
+        ('set_model', original_set_model, REQUEST_MODEL),
+        ('rewind_files', original_rewind_files, CLAUDE_REWIND_USER_MESSAGE_ID),
+        ('stop_task', original_stop_task, CLAUDE_TASK_ID),
+    )
+    for span_name, original_method, attr_key in control_method_specs:
+        if original_method is None:  # pragma: no cover
+            continue
+        setattr(cls, span_name, _make_control_patch(logfire_claude, span_name, original_method, attr_key))
+
+    # MCP methods take ``server_name`` as the first arg; reconnect has just
+    # that, toggle has both ``server_name`` and ``enabled``. Different
+    # surface shape from the simple ``(value)`` control methods above so
+    # patched separately. Span names get a ``mcp.`` prefix because they're
+    # sub-domain operations (two methods, one server-name surface) rather
+    # than session-lifecycle calls — group cleanly in dashboards filtering
+    # by span_name.
+    if original_reconnect_mcp_server is not None:
+
+        @functools.wraps(original_reconnect_mcp_server)
+        async def patched_reconnect_mcp_server(self: Any, server_name: str, *args: Any, **kwargs: Any) -> Any:
+            with _traced_span(logfire_claude, 'mcp.reconnect', **{CLAUDE_MCP_SERVER_NAME: server_name}):
+                return await original_reconnect_mcp_server(self, server_name, *args, **kwargs)
+
+        cls.reconnect_mcp_server = patched_reconnect_mcp_server
+
+    if original_toggle_mcp_server is not None:
+
+        @functools.wraps(original_toggle_mcp_server)
+        async def patched_toggle_mcp_server(self: Any, server_name: str, enabled: bool, *args: Any, **kwargs: Any) -> Any:
+            with _traced_span(
+                logfire_claude,
+                'mcp.toggle',
+                **{CLAUDE_MCP_SERVER_NAME: server_name, CLAUDE_MCP_ENABLED: enabled},
+            ):
+                return await original_toggle_mcp_server(self, server_name, enabled, *args, **kwargs)
+
+        cls.toggle_mcp_server = patched_toggle_mcp_server
 
     @contextmanager
     def uninstrument_context():
         try:
             yield
         finally:
+            # Pre-#11 methods are guaranteed to exist on every SDK version
+            # the integration supports — restore unconditionally.
             cls.__init__ = original_init
             cls.query = original_query
             cls.receive_response = original_receive_response
+            # Issue-#11 methods are conditionally present (e.g. ``rewind_files``
+            # / ``stop_task`` / ``reconnect_mcp_server`` are recent additions);
+            # restore only what we captured to avoid setting stale-None on
+            # older SDKs.
+            for attr, original in (
+                ('receive_messages', original_receive_messages),
+                ('connect', original_connect),
+                ('disconnect', original_disconnect),
+                ('interrupt', original_interrupt),
+                ('set_permission_mode', original_set_permission_mode),
+                ('set_model', original_set_model),
+                ('rewind_files', original_rewind_files),
+                ('reconnect_mcp_server', original_reconnect_mcp_server),
+                ('toggle_mcp_server', original_toggle_mcp_server),
+                ('stop_task', original_stop_task),
+            ):
+                if original is not None:
+                    setattr(cls, attr, original)
             cls._is_instrumented_by_logfire = False  # pyright: ignore[reportAttributeAccessIssue]
 
     return uninstrument_context()
+
+
+def _annotate_error_span(span: LogfireSpan, exc: BaseException) -> None:
+    """Annotate a span with error.type + level=error before re-raising.
+
+    For ``ProcessError`` (the only SDK exception class that carries
+    structured detail), also surfaces ``exit_code`` and a truncated
+    ``stderr`` (first 200 chars — the field can carry megabytes of
+    subprocess output). Only invoked from the issue-#11 lifecycle/control
+    method patches.
+    """
+    span.set_attribute(ERROR_TYPE, exc.__class__.__name__)
+    span.set_level('error')
+    process_error = getattr(claude_agent_sdk, 'ProcessError', None)
+    if process_error is not None and isinstance(exc, process_error):
+        if (exit_code := getattr(exc, 'exit_code', None)) is not None:
+            span.set_attribute(CLAUDE_PROCESS_EXIT_CODE, exit_code)
+        if (stderr := getattr(exc, 'stderr', None)) is not None:
+            span.set_attribute(CLAUDE_PROCESS_STDERR, str(stderr)[:200])
+
+
+@contextmanager
+def _traced_span(logfire_claude: Logfire, span_name: str, **attrs: Any) -> Any:
+    """Open a span and annotate any escaping exception via ``_annotate_error_span``.
+
+    Shared by every issue-#11 lifecycle/control patch — see ``_annotate_error_span``
+    for the annotation contract.
+    """
+    with logfire_claude.span(span_name, **attrs) as span:
+        try:
+            yield span
+        except BaseException as exc:
+            _annotate_error_span(span, exc)
+            raise
+
+
+def _make_control_patch(
+    logfire_claude: Logfire,
+    span_name: str,
+    original_method: Any,
+    attr_key: str | None,
+) -> Any:
+    """Factory for the simple control-method patches (issue #11).
+
+    Each control method (``set_model`` / ``set_permission_mode`` / ...)
+    has the same span shape: open a span named after the method, optionally
+    capture the first positional / keyword arg under a claude.* attribute,
+    await the original, mark error on exception. Factored so adding a new
+    method is one line in ``control_method_specs``.
+
+    ``attr_key=None`` means the method takes no observable input
+    (``interrupt``); the span carries timing only.
+    """
+
+    @functools.wraps(original_method)
+    async def patched(self: Any, *args: Any, **kwargs: Any) -> Any:
+        attrs: dict[str, Any] = {}
+        if attr_key is not None:
+            value = args[0] if args else next(iter(kwargs.values()), None)
+            if value is not None:
+                attrs[attr_key] = value
+        with _traced_span(logfire_claude, span_name, **attrs):
+            return await original_method(self, *args, **kwargs)
+
+    return patched
 
 
 def _inject_tracing_hooks(options: Any) -> None:

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -235,6 +235,29 @@ CLAUDE_PERMISSION_RESULT_UPDATED_PERMISSIONS = 'claude.permission_result.updated
 # value lands here. Absent on the happy path where pre == executed.
 CLAUDE_TOOL_CALL_ARGUMENTS_ORIGINAL = 'claude.tool_call.arguments.original'
 
+# Lifecycle / control-method attributes (issue #11). Captured on the spans
+# wrapping ``ClaudeSDKClient.connect`` / ``disconnect`` / ``set_model`` /
+# ``set_permission_mode`` / ``rewind_files`` / ``reconnect_mcp_server`` /
+# ``toggle_mcp_server`` / ``stop_task`` / ``interrupt``.
+#
+# None on SAFE_KEYS:
+#   * ``claude.process.stderr`` and ``claude.cli_path`` can carry filesystem
+#     paths matching default scrub patterns (``auth``, ``secret``,
+#     ``private_key``, etc.) — value-level redaction is the safer default.
+#   * The remaining attrs (``exit_code`` int, ``mcp.enabled`` bool,
+#     ``mcp.server_name`` / ``task_id`` / ``rewind.user_message_id`` —
+#     short operator-set identifiers) are not type-sensitive but are also
+#     omitted from SAFE_KEYS for symmetry; default scrubbing is a no-op
+#     on integers / booleans, and the identifier strings are unlikely
+#     to legitimately contain credentials.
+CLAUDE_CLI_PATH = 'claude.cli_path'
+CLAUDE_PROCESS_EXIT_CODE = 'claude.process.exit_code'
+CLAUDE_PROCESS_STDERR = 'claude.process.stderr'
+CLAUDE_REWIND_USER_MESSAGE_ID = 'claude.rewind.user_message_id'
+CLAUDE_MCP_SERVER_NAME = 'claude.mcp.server_name'
+CLAUDE_MCP_ENABLED = 'claude.mcp.enabled'
+CLAUDE_TASK_ID = 'claude.task_id'
+
 # Type definitions for message parts and messages
 
 

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -40,12 +40,14 @@ from claude_agent_sdk import (
     ToolResultBlock,
     ToolUseBlock,
 )
+from claude_agent_sdk._errors import CLINotFoundError, ProcessError
 from claude_agent_sdk.types import HookContext
 from dirty_equals import IsStr
 from inline_snapshot import snapshot
 
 import logfire
 from logfire._internal.integrations.claude_agent_sdk import (
+    _annotate_error_span,
     _clear_state,
     _content_blocks_to_output_messages,
     _ConversationState,
@@ -619,9 +621,9 @@ def test_options_attrs_rejects_non_options_object() -> None:
     from types import SimpleNamespace
 
     fake = SimpleNamespace(
-        model=123,                       # wrong type
-        permission_mode=['nonsense'],    # wrong type
-        max_turns='five',                # wrong type
+        model=123,  # wrong type
+        permission_mode=['nonsense'],  # wrong type
+        max_turns='five',  # wrong type
     )
     assert _options_attrs(fake) == {}
 
@@ -1470,7 +1472,8 @@ async def test_record_permission_result_allow_with_mutation_logs_updated_input(e
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     log = next(
-        s for s in spans
+        s
+        for s in spans
         if s['name'] == 'Hook: PermissionResult ({behavior})'
         and s['attributes'].get('claude.permission_result.behavior') == 'allow'
     )
@@ -1492,7 +1495,8 @@ async def test_record_permission_result_allow_plain_skips_updated_attrs(exporter
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     log = next(
-        s for s in spans
+        s
+        for s in spans
         if s['name'] == 'Hook: PermissionResult ({behavior})'
         and s['attributes'].get('claude.permission_result.behavior') == 'allow'
     )
@@ -1576,7 +1580,8 @@ async def test_record_permission_result_deny_with_no_open_span(exporter: TestExp
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     log = next(
-        s for s in spans
+        s
+        for s in spans
         if s['name'] == 'Hook: PermissionResult ({behavior})'
         and s['attributes'].get('claude.permission_result.behavior') == 'deny'
     )
@@ -1599,7 +1604,8 @@ async def test_record_permission_result_deny_with_interrupt_true(exporter: TestE
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     log = next(
-        s for s in spans
+        s
+        for s in spans
         if s['name'] == 'Hook: PermissionResult ({behavior})'
         and s['attributes'].get('claude.permission_result.behavior') == 'deny'
     )
@@ -1659,7 +1665,8 @@ async def test_wrap_can_use_tool_emits_log_under_active_root(exporter: TestExpor
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     root_span = next(s for s in spans if s['name'] == 'invoke_agent')
     log = next(
-        s for s in spans
+        s
+        for s in spans
         if s['name'] == 'Hook: PermissionResult ({behavior})'
         and s['attributes'].get('claude.permission_result.behavior') == 'allow'
     )
@@ -1689,6 +1696,309 @@ def test_inject_hooks_skips_can_use_tool_when_none() -> None:
     assert options.can_use_tool is None
     _inject_tracing_hooks(options)
     assert options.can_use_tool is None
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle / control-method tests (issue #11).
+#
+# Each ``ClaudeSDKClient`` lifecycle (``connect`` / ``disconnect``) and
+# control method (``set_model`` / ``set_permission_mode`` / ``rewind_files``
+# / ``stop_task`` / ``interrupt`` / ``reconnect_mcp_server`` /
+# ``toggle_mcp_server``) is wrapped in a span. Six of these don't fire
+# under non-interactive SDK transport (need real CLI / MCP / file
+# checkpointing setup) and these unit tests are the only coverage they
+# get — assertions are intentionally specific.
+# ---------------------------------------------------------------------------
+
+
+def _make_dummy_client() -> ClaudeSDKClient:
+    """A ``ClaudeSDKClient`` with a stubbed-in ``_query`` so control methods
+    can be invoked without spinning up a real subprocess.
+
+    Distinct from ``_make_client`` (cassette-based, replays a recorded
+    session via ``fake_claude.py``): control methods operate on an
+    already-connected ``_query`` object — no transport / message stream
+    involvement — so a direct stub is the cleanest test surface.
+
+    The integration's ``patched_init`` runs ``_inject_tracing_hooks`` on
+    options, which is a no-op for our purposes here.
+    """
+
+    class _StubQuery:
+        async def interrupt(self) -> None:
+            return None
+
+        async def set_permission_mode(self, mode: str) -> None:
+            return None
+
+        async def set_model(self, model: str | None) -> None:
+            return None
+
+        async def rewind_files(self, user_message_id: str) -> None:
+            return None
+
+        async def reconnect_mcp_server(self, server_name: str) -> None:
+            return None
+
+        async def toggle_mcp_server(self, server_name: str, enabled: bool) -> None:
+            return None
+
+        async def stop_task(self, task_id: str) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    client = ClaudeSDKClient(options=ClaudeAgentOptions())
+    # Bypass ``connect`` — populate ``_query`` directly so the control
+    # methods' "Not connected" guards pass.
+    client._query = _StubQuery()  # type: ignore[assignment]
+    client._transport = Mock()
+    return client
+
+
+@pytest.mark.anyio
+async def test_receive_messages_produces_full_invoke_agent_tree(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, exporter: TestExporter
+) -> None:
+    """``receive_messages`` was a complete observability black hole pre-#11.
+    The patch makes it produce the same ``invoke_agent`` / ``chat`` /
+    ``Hook: *`` tree as ``receive_response``. Locks parity end-to-end via
+    a fake-claude cassette replay.
+    """
+    record = request.config.getoption('--record-claude-cassettes', default=False)
+    client = _make_client('basic_conversation.json', monkeypatch=monkeypatch, record=bool(record))
+    try:
+        await client.connect()
+        await client.query('What is 2+2?')
+        collected: list[Any] = []
+        async for msg in client.receive_messages():
+            collected.append(msg)
+            if any(type(m).__name__ == 'ResultMessage' for m in collected):
+                break
+    finally:
+        await _close_sdk_streams(client)
+        await client.disconnect()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    names = [s['name'] for s in spans]
+    # Single invoke_agent — the nesting fix prevents the inner call
+    # to receive_messages from opening a second one when patched.
+    assert names.count('invoke_agent') == 1
+    # Same body the receive_response cassette test asserts: chat span
+    # parented to invoke_agent, lifecycle spans top-level.
+    assert any(n.startswith('chat ') for n in names)
+    assert 'connect' in names
+    assert 'disconnect' in names
+
+
+@pytest.mark.anyio
+async def test_receive_response_calling_receive_messages_does_not_double_invoke_agent(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch, exporter: TestExporter
+) -> None:
+    """``receive_response`` calls ``self.receive_messages()`` internally.
+    With both patched, naive wrapping would open two ``invoke_agent`` spans
+    (one per wrapper). The ``_drive_invoke_agent`` nesting check at
+    ``_get_state() is not None`` prevents this. Locks the contract.
+    """
+    record = request.config.getoption('--record-claude-cassettes', default=False)
+    client = _make_client('basic_conversation.json', monkeypatch=monkeypatch, record=bool(record))
+    try:
+        await client.connect()
+        await client.query('What is 2+2?')
+        async for _ in client.receive_response():
+            pass
+    finally:
+        await _close_sdk_streams(client)
+        await client.disconnect()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    invoke_agents = [s for s in spans if s['name'] == 'invoke_agent']
+    assert len(invoke_agents) == 1
+
+
+@pytest.mark.anyio
+async def test_connect_error_path_marks_span_with_error_type(exporter: TestExporter) -> None:
+    """``CLINotFoundError`` raised during ``connect`` produces a span at
+    error level with ``error.type='CLINotFoundError'`` (the short class name
+    via ``_annotate_error_span``). Locks the audit-trail for deployments
+    where the CLI binary goes missing — pre-#11 these errors vanished into
+    user code.
+    """
+    options = ClaudeAgentOptions(cli_path='/nonexistent/path/claude-cli')
+    client = ClaudeSDKClient(options=options)
+    with pytest.raises(CLINotFoundError):
+        await client.connect()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    connect_spans = [s for s in spans if s['name'] == 'connect']
+    # The SDK's ``connect()`` calls ``self.disconnect()`` in its except
+    # cleanup, so a child ``disconnect`` span lives under the failed
+    # ``connect``. We're asserting on the outer one.
+    failed_connect = next(s for s in connect_spans if s['attributes'].get('error.type') == 'CLINotFoundError')
+    assert failed_connect['attributes']['logfire.level_num'] == 17  # error
+    assert failed_connect['attributes']['claude.cli_path'] == '/nonexistent/path/claude-cli'
+
+
+@pytest.mark.anyio
+async def test_annotate_error_span_captures_process_error_detail(exporter: TestExporter) -> None:
+    """``_annotate_error_span`` uses ``isinstance(exc, ProcessError)`` to
+    surface ``exit_code`` + truncated ``stderr``. Other exception types
+    only get ``error.type`` + level=error.
+
+    Locked here because a real ``ProcessError`` is hard to provoke in a
+    unit test (requires a CLI subprocess that exits non-zero); driving
+    the helper directly is the cleanest coverage for the structured-detail
+    capture path.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+
+    # 250-char stderr to lock the 200-char truncation.
+    long_stderr = 'fatal: ' + ('x' * 250)
+    with logfire_instance.span('connect') as span:
+        _annotate_error_span(
+            span,
+            ProcessError(message='subprocess crashed', exit_code=137, stderr=long_stderr),
+        )
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(spans_iter for spans_iter in spans if spans_iter['name'] == 'connect')
+    assert s['attributes']['error.type'] == 'ProcessError'
+    assert s['attributes']['logfire.level_num'] == 17  # error
+    assert s['attributes']['claude.process.exit_code'] == 137
+    assert len(s['attributes']['claude.process.stderr']) == 200
+
+
+@pytest.mark.anyio
+async def test_set_model_captures_model_attribute(exporter: TestExporter) -> None:
+    """``set_model('claude-sonnet-4-6')`` produces a ``set_model`` span
+    with ``gen_ai.request.model`` set — the bit that makes mid-session
+    model switches visible for cost attribution.
+    """
+    client = _make_dummy_client()
+    await client.set_model('claude-sonnet-4-6')
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'set_model')
+    assert s['attributes']['gen_ai.request.model'] == 'claude-sonnet-4-6'
+
+
+@pytest.mark.anyio
+async def test_set_model_none_skips_attribute(exporter: TestExporter) -> None:
+    """``set_model(None)`` (revert to default) emits the span but no
+    ``gen_ai.request.model`` attr — locks the skip-when-None semantic
+    so a regression that started emitting ``model='None'`` strings is
+    caught."""
+    client = _make_dummy_client()
+    await client.set_model(None)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'set_model')
+    assert 'gen_ai.request.model' not in s['attributes']
+
+
+@pytest.mark.anyio
+async def test_set_permission_mode_captures_mode(exporter: TestExporter) -> None:
+    """``set_permission_mode('acceptEdits')`` → span with
+    ``claude.permission_mode='acceptEdits'``. Reuses the existing
+    ``CLAUDE_PERMISSION_MODE`` constant from the options-side capture
+    in #8."""
+    client = _make_dummy_client()
+    await client.set_permission_mode('acceptEdits')  # type: ignore[arg-type]
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'set_permission_mode')
+    assert s['attributes']['claude.permission_mode'] == 'acceptEdits'
+
+
+@pytest.mark.anyio
+async def test_rewind_files_captures_user_message_id(exporter: TestExporter) -> None:
+    client = _make_dummy_client()
+    await client.rewind_files('msg_uuid_abc')
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'rewind_files')
+    assert s['attributes']['claude.rewind.user_message_id'] == 'msg_uuid_abc'
+
+
+@pytest.mark.anyio
+async def test_stop_task_captures_task_id(exporter: TestExporter) -> None:
+    client = _make_dummy_client()
+    await client.stop_task('task_abc123')
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'stop_task')
+    assert s['attributes']['claude.task_id'] == 'task_abc123'
+
+
+@pytest.mark.anyio
+async def test_interrupt_emits_span_with_no_input_attrs(exporter: TestExporter) -> None:
+    """``interrupt`` takes no observable input — the span carries timing
+    only. Locks: the patch doesn't accidentally surface unrelated kwargs."""
+    client = _make_dummy_client()
+    await client.interrupt()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'interrupt')
+    for absent in (
+        'claude.permission_mode',
+        'gen_ai.request.model',
+        'claude.rewind.user_message_id',
+        'claude.task_id',
+        'claude.mcp.server_name',
+    ):
+        assert absent not in s['attributes']
+
+
+@pytest.mark.anyio
+async def test_reconnect_mcp_server_captures_server_name(exporter: TestExporter) -> None:
+    client = _make_dummy_client()
+    await client.reconnect_mcp_server('my-server')
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'mcp.reconnect')
+    assert s['attributes']['claude.mcp.server_name'] == 'my-server'
+
+
+@pytest.mark.anyio
+async def test_toggle_mcp_server_captures_server_name_and_enabled(exporter: TestExporter) -> None:
+    """Multi-arg shape: server_name + enabled both surfaced."""
+    client = _make_dummy_client()
+    await client.toggle_mcp_server('my-server', enabled=False)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    s = next(s for s in spans if s['name'] == 'mcp.toggle')
+    assert s['attributes']['claude.mcp.server_name'] == 'my-server'
+    assert s['attributes']['claude.mcp.enabled'] is False
+
+
+def test_all_lifecycle_and_control_methods_are_wrapped() -> None:
+    """Locks the issue-#11 wrap-every-method contract: every lifecycle and
+    control method on ``ClaudeSDKClient`` carries a ``__wrapped__`` sentinel
+    pointing at the SDK's original implementation. A regression that drops
+    one method's patch (e.g. forgets to add to ``control_method_specs``)
+    silently breaks observability for that surface — the test is the gate.
+
+    The autouse fixture has already instrumented at this point.
+    """
+    cls = ClaudeSDKClient
+    for name in (
+        'connect',
+        'disconnect',
+        'receive_messages',
+        'interrupt',
+        'set_permission_mode',
+        'set_model',
+        'rewind_files',
+        'reconnect_mcp_server',
+        'toggle_mcp_server',
+        'stop_task',
+        # Pre-#11 patches still in place too.
+        'query',
+        'receive_response',
+    ):
+        fn = getattr(cls, name)
+        assert getattr(fn, '__wrapped__', None) is not None, f'{name} should be wrapped'
 
 
 @pytest.mark.anyio
@@ -1724,11 +2034,31 @@ async def test_basic_conversation_cassette(
     assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {
+                'name': 'connect',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_basic_conversation_cassette',
+                    'code.lineno': 123,
+                    'claude.cli_path': IsStr(regex=r'.*/fake_claude\.py$'),
+                    'logfire.msg_template': 'connect',
+                    'logfire.msg': 'connect',
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {'claude.cli_path': {}},
+                    },
+                    'logfire.span_type': 'span',
+                },
+            },
+            {
                 'name': 'chat claude-sonnet-4-6',
-                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'start_time': 2000000000,
-                'end_time': 3000000000,
+                'context': {'trace_id': 2, 'span_id': 5, 'is_remote': False},
+                'parent': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'start_time': 4000000000,
+                'end_time': 5000000000,
                 'attributes': {
                     'code.filepath': 'test_claude_agent_sdk.py',
                     'code.function': 'test_basic_conversation_cassette',
@@ -1736,28 +2066,31 @@ async def test_basic_conversation_cassette(
                     'gen_ai.operation.name': 'chat',
                     'gen_ai.provider.name': 'anthropic',
                     'gen_ai.system': 'anthropic',
-                    'gen_ai.response.model': 'claude-sonnet-4-6',
-                    'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
-                    'gen_ai.output.messages': [{'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]}],
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
+                    'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
+                    'logfire.msg_template': 'chat',
+                    'gen_ai.output.messages': [{'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]}],
+                    'logfire.msg': 'chat claude-sonnet-4-6',
+                    'logfire.span_type': 'span',
                     'gen_ai.usage.partial.input_tokens': 9344,
-                    'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.usage.partial.output_tokens': 1,
                     'gen_ai.usage.partial.cache_read.input_tokens': 7166,
                     'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
-                    'logfire.msg_template': 'chat',
-                    'logfire.msg': 'chat claude-sonnet-4-6',
+                    'gen_ai.response.id': 'msg_01BxK8UH2LyuFLVXSPamqHam',
+                    'claude.message.uuid': 'ce1101bc-27c6-41b1-ae16-5edf06b0927c',
+                    'gen_ai.request.model': 'claude-sonnet-4-6',
+                    'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
                             'gen_ai.operation.name': {},
                             'gen_ai.provider.name': {},
                             'gen_ai.system': {},
-                            'gen_ai.response.model': {},
-                            'gen_ai.system_instructions': {'type': 'array'},
-                            'gen_ai.output.messages': {'type': 'array'},
-                            'gen_ai.request.model': {},
                             'gen_ai.input.messages': {'type': 'array'},
+                            'gen_ai.output.messages': {'type': 'array'},
+                            'gen_ai.system_instructions': {'type': 'array'},
+                            'gen_ai.request.model': {},
+                            'gen_ai.response.model': {},
                             'gen_ai.usage.partial.input_tokens': {},
                             'gen_ai.usage.partial.output_tokens': {},
                             'gen_ai.usage.partial.cache_read.input_tokens': {},
@@ -1766,17 +2099,14 @@ async def test_basic_conversation_cassette(
                             'claude.message.uuid': {},
                         },
                     },
-                    'gen_ai.response.id': 'msg_01BxK8UH2LyuFLVXSPamqHam',
-                    'claude.message.uuid': 'ce1101bc-27c6-41b1-ae16-5edf06b0927c',
-                    'logfire.span_type': 'span',
                 },
             },
             {
                 'name': 'invoke_agent',
-                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
                 'parent': None,
-                'start_time': 1000000000,
-                'end_time': 4000000000,
+                'start_time': 3000000000,
+                'end_time': 6000000000,
                 'attributes': {
                     'code.filepath': 'test_claude_agent_sdk.py',
                     'code.function': 'test_basic_conversation_cassette',
@@ -1801,6 +2131,7 @@ async def test_basic_conversation_cassette(
                     'duration_api_ms': 2257,
                     'claude.result.subtype': 'success',
                     'claude.result.text': '4',
+                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'claude.model_usage': {
                         'claude-sonnet-4-6': {
                             'inputTokens': 3,
@@ -1813,7 +2144,6 @@ async def test_basic_conversation_cassette(
                             'maxOutputTokens': 32000,
                         }
                     },
-                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'pydantic_ai.all_messages': [
@@ -1840,13 +2170,28 @@ async def test_basic_conversation_cassette(
                             'duration_api_ms': {},
                             'claude.result.subtype': {},
                             'claude.result.text': {},
-                            'claude.model_usage': {'type': 'object'},
                             'gen_ai.response.finish_reasons': {'type': 'array'},
+                            'claude.model_usage': {'type': 'object'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                             'pydantic_ai.all_messages': {'type': 'array'},
                         },
                     },
+                },
+            },
+            {
+                'name': 'disconnect',
+                'context': {'trace_id': 3, 'span_id': 7, 'is_remote': False},
+                'parent': None,
+                'start_time': 7000000000,
+                'end_time': 8000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_basic_conversation_cassette',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'disconnect',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'disconnect',
                 },
             },
         ]
@@ -2224,11 +2569,31 @@ async def test_server_tool_blocks_cassette(
     assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {
+                'name': 'connect',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_server_tool_blocks_cassette',
+                    'code.lineno': 123,
+                    'claude.cli_path': IsStr(regex=r'.*/fake_claude\.py$'),
+                    'logfire.msg_template': 'connect',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'connect',
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {'claude.cli_path': {}},
+                    },
+                },
+            },
+            {
                 'name': 'chat claude-sonnet-4-6',
-                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'start_time': 2000000000,
-                'end_time': 3000000000,
+                'context': {'trace_id': 2, 'span_id': 5, 'is_remote': False},
+                'parent': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'start_time': 4000000000,
+                'end_time': 5000000000,
                 'attributes': {
                     'code.filepath': 'test_claude_agent_sdk.py',
                     'code.function': 'test_server_tool_blocks_cassette',
@@ -2239,7 +2604,6 @@ async def test_server_tool_blocks_cassette(
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
                     'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
                     'logfire.msg_template': 'chat',
-                    'logfire.span_type': 'span',
                     'gen_ai.output.messages': [
                         {
                             'role': 'assistant',
@@ -2260,15 +2624,16 @@ async def test_server_tool_blocks_cassette(
                             ],
                         }
                     ],
-                    'gen_ai.request.model': 'claude-sonnet-4-6',
-                    'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.msg': 'chat claude-sonnet-4-6',
+                    'logfire.span_type': 'span',
                     'gen_ai.usage.partial.input_tokens': 9344,
                     'gen_ai.usage.partial.output_tokens': 1,
                     'gen_ai.usage.partial.cache_read.input_tokens': 7166,
                     'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
                     'gen_ai.response.id': 'msg_01SrvToolFixturePpppppppppp',
                     'claude.message.uuid': 'f85bae42-7165-4a5e-991b-68c4fd586f8a',
+                    'gen_ai.request.model': 'claude-sonnet-4-6',
+                    'gen_ai.response.model': 'claude-sonnet-4-6',
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
@@ -2276,8 +2641,8 @@ async def test_server_tool_blocks_cassette(
                             'gen_ai.provider.name': {},
                             'gen_ai.system': {},
                             'gen_ai.input.messages': {'type': 'array'},
-                            'gen_ai.system_instructions': {'type': 'array'},
                             'gen_ai.output.messages': {'type': 'array'},
+                            'gen_ai.system_instructions': {'type': 'array'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                             'gen_ai.usage.partial.input_tokens': {},
@@ -2292,10 +2657,10 @@ async def test_server_tool_blocks_cassette(
             },
             {
                 'name': 'invoke_agent',
-                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
                 'parent': None,
-                'start_time': 1000000000,
-                'end_time': 4000000000,
+                'start_time': 3000000000,
+                'end_time': 6000000000,
                 'attributes': {
                     'code.filepath': 'test_claude_agent_sdk.py',
                     'code.function': 'test_server_tool_blocks_cassette',
@@ -2320,6 +2685,7 @@ async def test_server_tool_blocks_cassette(
                     'duration_api_ms': 2257,
                     'claude.result.subtype': 'success',
                     'claude.result.text': '4',
+                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'claude.model_usage': {
                         'claude-sonnet-4-6': {
                             'inputTokens': 3,
@@ -2332,7 +2698,6 @@ async def test_server_tool_blocks_cassette(
                             'maxOutputTokens': 32000,
                         }
                     },
-                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'pydantic_ai.all_messages': [
@@ -2377,14 +2742,29 @@ async def test_server_tool_blocks_cassette(
                             'duration_api_ms': {},
                             'claude.result.subtype': {},
                             'claude.result.text': {},
-                            'claude.model_usage': {'type': 'object'},
                             'gen_ai.response.finish_reasons': {'type': 'array'},
+                            'claude.model_usage': {'type': 'object'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                             'pydantic_ai.all_messages': {'type': 'array'},
                             'claude.tools_used': {'type': 'array'},
                         },
                     },
+                },
+            },
+            {
+                'name': 'disconnect',
+                'context': {'trace_id': 3, 'span_id': 7, 'is_remote': False},
+                'parent': None,
+                'start_time': 7000000000,
+                'end_time': 8000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_server_tool_blocks_cassette',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'disconnect',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'disconnect',
                 },
             },
         ]
@@ -2431,11 +2811,31 @@ async def test_ratelimit_and_mirror_error_cassette(
     assert exporter.exported_spans_as_dict(parse_json_attributes=True) == snapshot(
         [
             {
+                'name': 'connect',
+                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'parent': None,
+                'start_time': 1000000000,
+                'end_time': 2000000000,
+                'attributes': {
+                    'logfire.span_type': 'span',
+                    'logfire.msg_template': 'connect',
+                    'claude.cli_path': IsStr(regex=r'.*/fake_claude\.py$'),
+                    'logfire.msg': 'connect',
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
+                    'code.lineno': 123,
+                    'logfire.json_schema': {
+                        'type': 'object',
+                        'properties': {'claude.cli_path': {}},
+                    },
+                },
+            },
+            {
                 'name': 'rate_limit {status}',
-                'context': {'trace_id': 1, 'span_id': 5, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'start_time': 3000000000,
-                'end_time': 3000000000,
+                'context': {'trace_id': 2, 'span_id': 7, 'is_remote': False},
+                'parent': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'start_time': 5000000000,
+                'end_time': 5000000000,
                 'attributes': {
                     'logfire.span_type': 'log',
                     'logfire.level_num': 13,
@@ -2472,54 +2872,58 @@ async def test_ratelimit_and_mirror_error_cassette(
             },
             {
                 'name': 'mirror store error: {error}',
-                'context': {'trace_id': 1, 'span_id': 6, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'start_time': 4000000000,
-                'end_time': 4000000000,
+                'context': {'trace_id': 2, 'span_id': 8, 'is_remote': False},
+                'parent': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'start_time': 6000000000,
+                'end_time': 6000000000,
                 'attributes': {
-                    'logfire.span_type': 'log',
-                    'logfire.level_num': 17,
-                    'logfire.msg_template': 'mirror store error: {error}',
-                    'logfire.msg': 'mirror store error: store append timed out',
                     'code.filepath': 'test_claude_agent_sdk.py',
+                    'logfire.level_num': 17,
                     'code.function': 'test_ratelimit_and_mirror_error_cassette',
                     'code.lineno': 123,
                     'error': 'store append timed out',
                     'error.type': 'MirrorError',
                     'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
+                    'logfire.msg_template': 'mirror store error: {error}',
+                    'logfire.span_type': 'log',
+                    'logfire.msg': 'mirror store error: store append timed out',
                     'logfire.json_schema': {
                         'type': 'object',
-                        'properties': {'error': {}, 'error.type': {}, 'gen_ai.conversation.id': {}},
+                        'properties': {
+                            'error': {},
+                            'error.type': {},
+                            'gen_ai.conversation.id': {},
+                        },
                     },
                 },
             },
             {
                 'name': 'chat claude-sonnet-4-6',
-                'context': {'trace_id': 1, 'span_id': 3, 'is_remote': False},
-                'parent': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
-                'start_time': 2000000000,
-                'end_time': 5000000000,
+                'context': {'trace_id': 2, 'span_id': 5, 'is_remote': False},
+                'parent': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
+                'start_time': 4000000000,
+                'end_time': 7000000000,
                 'attributes': {
                     'code.filepath': 'test_claude_agent_sdk.py',
                     'code.function': 'test_ratelimit_and_mirror_error_cassette',
-                    'code.lineno': 123,
                     'gen_ai.operation.name': 'chat',
                     'gen_ai.provider.name': 'anthropic',
                     'gen_ai.system': 'anthropic',
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
                     'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
-                    'logfire.msg_template': 'chat',
-                    'logfire.span_type': 'span',
+                    'code.lineno': 123,
                     'gen_ai.output.messages': [{'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]}],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
-                    'logfire.msg': 'chat claude-sonnet-4-6',
                     'gen_ai.usage.partial.input_tokens': 9344,
                     'gen_ai.usage.partial.output_tokens': 1,
                     'gen_ai.usage.partial.cache_read.input_tokens': 7166,
                     'gen_ai.usage.partial.cache_creation.input_tokens': 2175,
                     'gen_ai.response.id': 'msg_01BxK8UH2LyuFLVXSPamqHam',
                     'claude.message.uuid': 'ce1101bc-27c6-41b1-ae16-5edf06b0927c',
+                    'logfire.msg_template': 'chat',
+                    'logfire.msg': 'chat claude-sonnet-4-6',
+                    'logfire.span_type': 'span',
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
@@ -2543,34 +2947,34 @@ async def test_ratelimit_and_mirror_error_cassette(
             },
             {
                 'name': 'invoke_agent',
-                'context': {'trace_id': 1, 'span_id': 1, 'is_remote': False},
+                'context': {'trace_id': 2, 'span_id': 3, 'is_remote': False},
                 'parent': None,
-                'start_time': 1000000000,
-                'end_time': 6000000000,
+                'start_time': 3000000000,
+                'end_time': 8000000000,
                 'attributes': {
-                    'code.filepath': 'test_claude_agent_sdk.py',
-                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
-                    'code.lineno': 123,
+                    'logfire.span_type': 'span',
+                    'logfire.msg_template': 'invoke_agent',
                     'gen_ai.operation.name': 'invoke_agent',
                     'gen_ai.provider.name': 'anthropic',
                     'gen_ai.system': 'anthropic',
                     'gen_ai.agent.name': 'claude-code',
                     'gen_ai.input.messages': [{'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]}],
                     'gen_ai.system_instructions': [{'type': 'text', 'content': 'Be helpful'}],
-                    'logfire.msg_template': 'invoke_agent',
                     'logfire.msg': 'invoke_agent',
-                    'logfire.span_type': 'span',
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
                     'gen_ai.usage.input_tokens': 9344,
                     'gen_ai.usage.output_tokens': 5,
                     'gen_ai.usage.cache_read.input_tokens': 7166,
                     'gen_ai.usage.cache_creation.input_tokens': 2175,
                     'operation.cost': 0.01039005,
-                    'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
+                    'code.lineno': 123,
                     'num_turns': 1,
                     'duration_ms': 2263,
                     'duration_api_ms': 2257,
                     'claude.result.subtype': 'success',
                     'claude.result.text': '4',
+                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'claude.model_usage': {
                         'claude-sonnet-4-6': {
                             'inputTokens': 3,
@@ -2583,13 +2987,13 @@ async def test_ratelimit_and_mirror_error_cassette(
                             'maxOutputTokens': 32000,
                         }
                     },
-                    'gen_ai.response.finish_reasons': ['end_turn'],
                     'gen_ai.request.model': 'claude-sonnet-4-6',
                     'gen_ai.response.model': 'claude-sonnet-4-6',
                     'pydantic_ai.all_messages': [
                         {'role': 'user', 'parts': [{'type': 'text', 'content': 'What is 2+2?'}]},
                         {'role': 'assistant', 'parts': [{'type': 'text', 'content': '4'}]},
                     ],
+                    'gen_ai.conversation.id': '7ed3c21d-374b-491a-8c66-05e191f6a0be',
                     'logfire.json_schema': {
                         'type': 'object',
                         'properties': {
@@ -2610,13 +3014,28 @@ async def test_ratelimit_and_mirror_error_cassette(
                             'duration_api_ms': {},
                             'claude.result.subtype': {},
                             'claude.result.text': {},
-                            'claude.model_usage': {'type': 'object'},
                             'gen_ai.response.finish_reasons': {'type': 'array'},
+                            'claude.model_usage': {'type': 'object'},
                             'gen_ai.request.model': {},
                             'gen_ai.response.model': {},
                             'pydantic_ai.all_messages': {'type': 'array'},
                         },
                     },
+                },
+            },
+            {
+                'name': 'disconnect',
+                'context': {'trace_id': 3, 'span_id': 9, 'is_remote': False},
+                'parent': None,
+                'start_time': 9000000000,
+                'end_time': 10000000000,
+                'attributes': {
+                    'code.filepath': 'test_claude_agent_sdk.py',
+                    'code.function': 'test_ratelimit_and_mirror_error_cassette',
+                    'code.lineno': 123,
+                    'logfire.msg_template': 'disconnect',
+                    'logfire.span_type': 'span',
+                    'logfire.msg': 'disconnect',
                 },
             },
         ]


### PR DESCRIPTION
Closes #11. Recon: https://github.com/oneryalcin/logfire/issues/11#issuecomment-4320503409. Empirical baseline: https://github.com/oneryalcin/logfire/issues/11#issuecomment-4320536042. Verify: https://github.com/oneryalcin/logfire/issues/11#issuecomment-4320597514.

## Summary

The integration patched only ``__init__`` / ``query`` / ``receive_response``. **Ten** other ``ClaudeSDKClient`` methods were untraced:

- ``connect`` / ``disconnect`` (lifecycle)
- ``receive_messages`` (alternate iterator — produced **zero** spans pre-PR)
- 7 control methods (``interrupt``, ``set_permission_mode``, ``set_model``, ``rewind_files``, ``reconnect_mcp_server``, ``toggle_mcp_server``, ``stop_task``)

Each gets a span. CLI startup latency, mid-session model switches (cost attribution), MCP toggle/reconnect (server flakiness), and connect-time errors (``CLINotFoundError`` / ``CLIConnectionError`` / ``ProcessError``) were all invisible before this patch.

## ``receive_messages`` parity — the biggest gap

Sessions using ``receive_messages`` over ``receive_response`` previously got **zero** observability — no ``invoke_agent``, no ``chat``, no ``execute_tool``, no hook events. The two iterators now share a factored ``_drive_invoke_agent`` body that opens the same span tree.

``receive_response`` calls ``self.receive_messages()`` internally (SDK ``client.py:566-580``). With both methods patched, naive wrapping opened **nested** ``invoke_agent`` spans. ``_drive_invoke_agent`` checks ``_get_state()`` at entry and delegates without re-wrapping when state is already set, preventing the double span. Locked by ``test_receive_response_calling_receive_messages_does_not_double_invoke_agent``.

## Error handling

``_annotate_error_span`` sets ``error.type`` from the exception class name and ``set_level('error')``. For ``ProcessError`` specifically, also captures ``exit_code`` and ``stderr`` (truncated to 200 chars — full output can be megabytes). Logfire's automatic exception recording attaches the full traceback under ``exception_type`` / ``exception.stacktrace`` independently, so the audit trail is complete (FQN class name + full stack + structured detail).

The SDK's ``connect()`` calls ``self.disconnect()`` in its except cleanup on failure — that nested invocation produces a child ``disconnect`` span under the failed ``connect``, faithfully reflecting the SDK's recovery sequence.

## Span shape

| Method | Span name | Notable attrs |
|---|---|---|
| ``connect`` | ``connect`` | ``claude.cli_path`` when set; ``error.type``/``claude.process.exit_code``/``claude.process.stderr`` on failure |
| ``disconnect`` | ``disconnect`` | none |
| ``receive_messages`` | ``invoke_agent`` (full tree) | identical to ``receive_response`` |
| ``set_model`` | ``set_model`` | ``gen_ai.request.model`` (absent if ``None``) |
| ``set_permission_mode`` | ``set_permission_mode`` | ``claude.permission_mode`` |
| ``rewind_files`` | ``rewind_files`` | ``claude.rewind.user_message_id`` |
| ``stop_task`` | ``stop_task`` | ``claude.task_id`` |
| ``interrupt`` | ``interrupt`` | timing only |
| ``reconnect_mcp_server`` | ``mcp.reconnect`` | ``claude.mcp.server_name`` |
| ``toggle_mcp_server`` | ``mcp.toggle`` | ``claude.mcp.server_name`` + ``claude.mcp.enabled`` |

Lifecycle / control spans are top-level when called between turns, or nested under the active ``invoke_agent`` if invoked mid-iteration (from a hook callback) via the existing thread-local OTel context.

The ``mcp.`` prefix groups MCP sub-domain operations distinctly from session-lifecycle calls in dashboards.

## SDK-drift safety

Every patched method uses ``getattr(cls, 'method_name', None)`` at capture time. Older SDKs missing newer methods (``rewind_files``, ``stop_task``, ``reconnect_mcp_server`` are recent additions) silently skip those patches — no crash on import. ``uninstrument_context`` restores conditionally, only what was originally captured.

## Privacy / SAFE_KEYS choices

**No SAFE_KEYS additions in this PR.** Per-attr rationale documented in ``semconv.py`` block-comment:

- ``claude.process.stderr`` / ``claude.cli_path``: filesystem paths can match scrub patterns (``auth``, ``secret``, ``private_key``); value-level redaction is the safer default.
- ``claude.process.exit_code`` (int) / ``claude.mcp.enabled`` (bool): scrubbing is a no-op on non-string types; omitted from SAFE_KEYS for symmetry.
- ``claude.mcp.server_name`` / ``claude.task_id`` / ``claude.rewind.user_message_id``: short operator-set identifiers, unlikely to legitimately contain credentials.

## Documented edge case: ``receive_messages`` break-without-aclose

``receive_messages`` has no auto-stop sentinel; users must ``break`` manually. If the break doesn't drain the generator (no explicit ``aclose``), Python's lazy generator cleanup leaves the OTel context for ``invoke_agent`` active. Operations called between break and ``aclose`` parent to the stale context. **Doesn't affect ``receive_response``** (auto-stops at ``ResultMessage``). Documented in user-facing docs with ``async with contextlib.aclosing(client.receive_messages())`` workaround.

## Architectural decision: ``invoke_agent`` lifecycle unchanged

Tempting to move ``invoke_agent`` to ``__aenter__`` / ``__aexit__`` so a single root span covers the whole session (the "two ``invoke_agent`` per session" wart from #9). **Not doing that here**: existing #6/#7/#8 work treats each ``ResultMessage`` as the discrete close of an ``invoke_agent`` (counters like ``claude.permission_denials``, ``claude.tools_used``, ``claude.user_prompt_count`` are all per-receive_response aggregates). Moving the root would change every counter's scope from "per query-cycle" to "per session". Filing as a separate follow-up issue.

## Empirical verification

``empirical/issue_11_connect_disconnect_control_methods.py`` exercises the live-observable path: ``connect`` (success + error via ``cli_path='/nonexistent'``), ``disconnect``, ``set_permission_mode``, ``set_model``, plus a ``receive_messages`` second turn.

- **Pre-patch**: 0 spans across both runs. Even ``CLINotFoundError`` vanished into user code with no logfire signal.
- **Post-patch**: ``connect`` span (top-level, with ``claude.cli_path``), ``invoke_agent`` / ``chat`` / Hook tree from both iterators, ``set_permission_mode`` and ``set_model`` spans top-level (between-turns context), ``CLINotFoundError`` produces span with ``error.type='CLINotFoundError'`` + level=error + full traceback.

5 methods can't fire under non-interactive SDK transport (``interrupt`` timing-sensitive, ``rewind_files`` needs file checkpointing, ``mcp.*`` need registered MCP servers, ``stop_task`` needs a long-running task) and are unit-test-only.

## Tests

13 new tests, all behavior locks (no snapshot diffs):

- ``receive_messages_produces_full_invoke_agent_tree`` — locks parity with receive_response (was zero spans pre-PR).
- ``receive_response_calling_receive_messages_does_not_double_invoke_agent`` — locks the nesting fix.
- ``connect_error_path_marks_span_with_error_type`` — real ``CLINotFoundError`` via bogus ``cli_path``; asserts ``error.type`` + level=error + ``claude.cli_path`` capture.
- ``annotate_error_span_captures_process_error_detail`` — drives ``_annotate_error_span`` directly with synthetic ``ProcessError(exit_code=137, stderr=...)``; locks the 200-char stderr truncation and exit_code capture.
- ``set_model_captures_model_attribute`` + ``set_model_none_skips_attribute`` — both branches.
- ``set_permission_mode_captures_mode``, ``rewind_files_captures_user_message_id``, ``stop_task_captures_task_id`` — single-arg control methods.
- ``interrupt_emits_span_with_no_input_attrs`` — no-arg method, asserts no spurious attrs.
- ``reconnect_mcp_server_captures_server_name``, ``toggle_mcp_server_captures_server_name_and_enabled`` — multi-arg MCP methods.
- ``all_lifecycle_and_control_methods_are_wrapped`` — locks the wrap-every-method contract via ``__wrapped__`` sentinel check.

3 cassette ``inline_snapshot``s regenerated to include the new ``connect`` / ``disconnect`` spans. Hardcoded developer-local path replaced with ``IsStr(regex=r'.*/fake_claude\.py$')`` for CI / cross-contributor portability.

## Adversarial review

Three reviewers in parallel before commit:

- **Opus (P0/P1)**: no blockers. 4 P2 items deferred — kwarg-picking brittleness in ``_make_control_patch`` (hypothetical SDK drift), ``mcp.`` dotted-namespace asymmetry (recon-locked), ``error.type`` short-name vs FQN (Logfire's auto-capture already provides FQN under ``exception_type``), ``stderr`` bytes guard (defensive). All accepted as future-fix candidates.
- **Sonnet (pattern compliance)**: caught hardcoded developer-local cassette path that would fail CI (**FIXED with ``IsStr``**); flagged missing user-facing docs (**FIXED in this PR**); SAFE_KEYS comment nuance (**FIXED with per-attr rationale split**); inline comments on ``mcp.`` prefix and unconditional-vs-conditional restore (**FIXED**). Multiple confirmations clean (test placement, fixture pattern, empirical-script style, no shim update).
- **code-simplifier**: factored ``_traced_span`` context manager consolidating the ``with span: try: except: _annotate_error_span; raise`` pattern across 5 sites. **-11 net lines**.

## Test plan

- [x] ``76 passed in test_claude_agent_sdk.py, 1 deselected`` (pre-existing ``test_tool_use_conversation_cassette`` flake).
- [x] ``test_secret_scrubbing`` — 12 passed (no SAFE_KEYS additions).
- [x] ``test_logfire_api`` — 3 passed, 1 skipped (no public-API change).
- [x] Empirical end-to-end through real Anthropic API + logfire UI: ``connect`` / ``disconnect`` / ``set_model`` / ``set_permission_mode`` all visible; ``CLINotFoundError`` captured at error level with full traceback; ``receive_messages`` now produces the full conversation tree.