### PR TITLE
Surface subagent observability: spans, Task* events, AgentDefinition metadata

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -130,6 +130,46 @@ These spans are top-level (no `invoke_agent` parent) when called between turns; 
 !!! note "`receive_messages` and the break-without-aclose edge case"
     `receive_messages` has no auto-stop sentinel, so the user must `break` to leave the loop. If the loop breaks without explicitly calling `await iter.aclose()` or using `async with closing(...)`, Python may not run the wrapper's `finally` block immediately — the OTel context for `invoke_agent` stays active until garbage collection runs, and any operations called between break and aclose (including `__aexit__`'s implicit `disconnect`) will parent to the stale `invoke_agent`. Doesn't affect `receive_response` (which auto-stops cleanly at `ResultMessage`). For `receive_messages`, prefer `async with contextlib.aclosing(client.receive_messages()) as it: ...` if you break early.
 
+## Subagent observability
+
+When the Claude CLI spawns a subagent via the Task tool, the integration opens a `subagent {agent_type}` child span under `invoke_agent` keyed by `agent_id` (`SubagentStart` hook). The span closes on the matching `SubagentStop`, and tool calls fired inside the subagent context re-parent their `execute_tool` child spans under the subagent span rather than the root `invoke_agent`. The trace tree looks like:
+
+```
+invoke_agent                      (root, parent thread)
+├── chat claude-sonnet-4-6        (parent's turn that emits the Task tool call)
+├── execute_tool Agent            (parent's view of the Task tool — current SDK
+│                                  surfaces the Task tool as 'Agent')
+├── subagent echo-helper          (sibling of execute_tool Agent)
+│   └── execute_tool Bash         (subagent's tool call, re-parented via agent_id)
+├── Task started                  (log under invoke_agent, info)
+├── Task progress                 (log; only fires for tool-using or background subagents)
+├── Task completed                (log; level depends on status)
+└── chat claude-sonnet-4-6        (parent's continuation)
+```
+
+Subagent attribution carried on the span:
+
+- `gen_ai.agent.name`, `claude.agent_id` (SDK-generated, opaque), `claude.agent_type` — the disambiguators when multiple subagents run in parallel.
+- `claude.subagent.last_assistant_message` — the verbatim final subagent text (allowlisted from scrubbing — model-generated content, mirrors `claude.stop.last_assistant_message`).
+- `claude.agent.transcript_path` — the subagent's own transcript JSONL, distinct from the parent session's.
+- When `ClaudeAgentOptions.agents[agent_type]` is configured (custom subagent definition), the full `AgentDefinition` metadata: `claude.agent.model`, `.description`, `.system_prompt` (from `AgentDefinition.prompt`, allowlisted), `.initial_prompt` (allowlisted), `.tools`, `.disallowed_tools`, `.skills`, `.memory`, `.background`, plus `claude.permission_mode` / `claude.max_turns` / `claude.effort` (re-using #8's constants — same configuration concepts; `span_name` distinguishes parent-options from subagent-definition values in dashboards).
+
+Three system-message events emitted during the subagent run surface as logs under `invoke_agent`:
+
+- **`Task started`** (info): carries `claude.task_id`, `claude.task.description`, `claude.task.type`, plus `gen_ai.tool.call.id` (the parent's Task tool id — for cross-span correlation).
+- **`Task progress`** (info): carries `claude.task.usage` (a TaskUsage dict — `total_tokens` / `tool_uses` / `duration_ms`) and `claude.task.last_tool_name`. Typically only fires for long-running / tool-using subagents; pure-text foreground subagents go straight from started to notification.
+- **`Task {status}`** (level depends on status): `completed` → info, `stopped` → warn, `failed` → error. Carries `claude.task.summary` (allowlisted — model-generated end-of-task text), `claude.task.output_file`, optional `claude.task.usage`. Does NOT escalate the parent `invoke_agent` span on `failed` — the parent isn't logically failed, just the subagent.
+
+`claude.subagent_count` lands on the root `invoke_agent` at conversation close (mirrors `claude.tools_used`), giving dashboards a per-session subagent-spawn count.
+
+### Parallel subagents
+
+Multiple Task dispatches in a single parent turn produce multiple concurrent `subagent` spans, each keyed by its own `agent_id`. The integration's per-conversation `subagent_spans` dict disambiguates by `agent_id`, so each subagent's tool calls correctly nest under its own span even when their hook callbacks interleave over the SDK's control channel.
+
+### Known limitation: subagent chat spans flatten under invoke_agent
+
+Subagent assistant turns produce `chat` spans flat under `invoke_agent` rather than nested under their parent `subagent` span. The dispatch loop's `handle_assistant_message` / `handle_user_message` don't have `agent_id` available — only `parent_tool_use_id`. Cross-correlation is still possible via the `claude.parent_tool_use_id` attribute already captured on each chat span, joined to the parent's `execute_tool Agent` span via `gen_ai.tool.call.id`. Fully nesting subagent chat spans under the subagent span requires building a `parent_tool_use_id → agent_id` map and refactoring `_ConversationState`'s span lifecycle; tracked separately to land with dedicated design + review attention.
+
 ## End-of-conversation result fields
 
 The `invoke_agent` span carries the conversation-level summary extracted from `ResultMessage`:

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -27,12 +27,26 @@ from claude_agent_sdk.types import HookContext, SyncHookJSONOutput
 # a redundant try/except on a module we've already imported above.
 RateLimitEvent = getattr(claude_agent_sdk, 'RateLimitEvent', None)
 MirrorErrorMessage = getattr(claude_agent_sdk, 'MirrorErrorMessage', None)
+# Issue #3 — Task* SystemMessage subclasses for subagent dispatch.
+TaskStartedMessage = getattr(claude_agent_sdk, 'TaskStartedMessage', None)
+TaskProgressMessage = getattr(claude_agent_sdk, 'TaskProgressMessage', None)
+TaskNotificationMessage = getattr(claude_agent_sdk, 'TaskNotificationMessage', None)
 
 from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
     AGENT_NAME,
+    CLAUDE_AGENT_BACKGROUND,
+    CLAUDE_AGENT_DESCRIPTION,
+    CLAUDE_AGENT_DISALLOWED_TOOLS,
     CLAUDE_AGENT_ID,
+    CLAUDE_AGENT_INITIAL_PROMPT,
+    CLAUDE_AGENT_MEMORY,
+    CLAUDE_AGENT_MODEL,
+    CLAUDE_AGENT_SKILLS,
+    CLAUDE_AGENT_SYSTEM_PROMPT,
+    CLAUDE_AGENT_TOOLS,
+    CLAUDE_AGENT_TRANSCRIPT_PATH,
     CLAUDE_AGENT_TYPE,
     CLAUDE_AGENTS,
     CLAUDE_ALLOWED_TOOLS,
@@ -83,7 +97,16 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_SKILLS_MODE,
     CLAUDE_STOP_HOOK_ACTIVE,
     CLAUDE_STOP_LAST_ASSISTANT_MESSAGE,
+    CLAUDE_SUBAGENT_COUNT,
+    CLAUDE_SUBAGENT_LAST_ASSISTANT_MESSAGE,
+    CLAUDE_TASK_DESCRIPTION,
     CLAUDE_TASK_ID,
+    CLAUDE_TASK_LAST_TOOL_NAME,
+    CLAUDE_TASK_OUTPUT_FILE,
+    CLAUDE_TASK_STATUS,
+    CLAUDE_TASK_SUMMARY,
+    CLAUDE_TASK_TYPE,
+    CLAUDE_TASK_USAGE,
     CLAUDE_TOOL_CALL_ARGUMENTS_ORIGINAL,
     CLAUDE_TOOLS_USED,
     CLAUDE_USER_PROMPT,
@@ -338,6 +361,26 @@ def _options_attrs(options: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
+def _tool_parent_otel_span(state: _ConversationState, input_data: Any) -> Any:
+    """Return the OTel span the ``execute_tool`` should parent under (issue #3).
+
+    When the tool-lifecycle hook fires inside a subagent context (``agent_id``
+    present in ``input_data`` AND the matching subagent span is open),
+    parent under the subagent span so the trace tree groups the subagent's
+    tool calls together. Otherwise parent under the root ``invoke_agent``.
+
+    Returns ``None`` if no usable parent OTel span is available (root span
+    already ended); caller should noop.
+    """
+    if isinstance(input_data, dict):
+        agent_id = input_data.get('agent_id')
+        if agent_id and (subagent_span := state.subagent_spans.get(agent_id)):
+            otel = subagent_span._span  # pyright: ignore[reportPrivateUsage]
+            if otel is not None:
+                return otel
+    return state.root_span._span  # pyright: ignore[reportPrivateUsage]
+
+
 async def pre_tool_use_hook(
     input_data: Any,
     tool_use_id: str | None,
@@ -364,7 +407,9 @@ async def pre_tool_use_hook(
         # Temporarily attach root span context so the new span is parented correctly,
         # then immediately detach. We can't keep the context attached because hooks
         # run in different async contexts (anyio tasks) and detaching later would fail.
-        otel_span = state.root_span._span  # pyright: ignore[reportPrivateUsage]
+        # Issue #3: when the call comes from a subagent (agent_id present),
+        # parent under the subagent span instead of the root invoke_agent.
+        otel_span = _tool_parent_otel_span(state, input_data)
         if otel_span is None:  # pragma: no cover
             return {}
         parent_ctx = trace_api.set_span_in_context(otel_span)
@@ -511,7 +556,7 @@ async def _run_hook(
     record_fn: Any,
     input_data: Any,
 ) -> None:
-    """Shared boilerplate for the 5 issue-#9 hook callbacks.
+    """Shared boilerplate for the 7 hook callbacks (5 from #9 + 2 from #3).
 
     Each callback runs ``record_fn(state, input_data)`` inside the root
     span's OTel context (hooks run in different anyio tasks so contextvars
@@ -600,6 +645,47 @@ async def permission_request_hook(
     on issue #9 for the boundary rationale.
     """
     await _run_hook(_record_permission_request, input_data)
+    return {}
+
+
+async def subagent_start_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Open a ``subagent <agent_type>`` span when a Task-spawned subagent starts (issue #3).
+
+    The span lives until the matching ``SubagentStop`` (keyed by ``agent_id``);
+    PreToolUse / PostToolUse / PostToolUseFailure hooks fired inside the
+    subagent context (with ``agent_id`` set on the hook input) re-parent
+    their ``execute_tool`` spans under it via ``_tool_parent_otel_span``
+    (called from ``pre_tool_use_hook``).
+    """
+    await _run_hook(_record_subagent_start, input_data)
+    return {}
+
+
+async def subagent_stop_hook(
+    input_data: Any,
+    _tool_use_id: str | None,
+    _context: HookContext,
+) -> SyncHookJSONOutput:
+    """Close the ``subagent`` span on ``SubagentStop`` (issue #3).
+
+    The span envelope itself is the event record — no separate log is
+    emitted. The lifetime of the ``subagent <agent_type>`` span is the
+    audit signal; ``claude.subagent.last_assistant_message`` and
+    ``claude.agent.transcript_path`` are set on the span at close time
+    rather than as a log, mirroring how ``execute_tool`` doesn't emit a
+    separate "tool finished" log.
+
+    Captures ``last_assistant_message`` defensively via ``.get()`` — the
+    field is on the wire but absent from ``SubagentStopHookInput`` (mirrors
+    issue #9's ``Stop`` hook). Carries the verbatim final subagent text,
+    which is high-value audit signal for "what did the subagent ultimately
+    say".
+    """
+    await _run_hook(_record_subagent_stop, input_data)
     return {}
 
 
@@ -714,6 +800,7 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                 root_span=root_span,
                 input_messages=input_messages,
                 system_instructions=span_data.get(SYSTEM_INSTRUCTIONS),
+                options=getattr(self, 'options', None),
             )
             _set_state(state)
             # Open the first chat span now — the LLM call starts at query time.
@@ -735,6 +822,18 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                             _record_rate_limit_event(logfire_claude, root_span, msg)
                         elif MirrorErrorMessage is not None and isinstance(msg, MirrorErrorMessage):
                             _record_mirror_error(logfire_claude, msg)
+                        # Issue #3 — Task* SystemMessage subclasses.
+                        # ``TaskProgressMessage`` typically only fires for
+                        # background / long-running subagents; foreground
+                        # subagents finish before any progress event. Patch
+                        # dispatches all 3 generically — fg/bg asymmetry is
+                        # an SDK-side emission detail.
+                        elif TaskStartedMessage is not None and isinstance(msg, TaskStartedMessage):
+                            _record_task_started(state, msg)
+                        elif TaskProgressMessage is not None and isinstance(msg, TaskProgressMessage):
+                            _record_task_progress(state, msg)
+                        elif TaskNotificationMessage is not None and isinstance(msg, TaskNotificationMessage):
+                            _record_task_notification(state, msg)
 
                     yield msg
             finally:
@@ -967,6 +1066,10 @@ def _inject_tracing_hooks(options: Any) -> None:
             ('PreCompact', pre_compact_hook),
             ('Notification', notification_hook),
             ('PermissionRequest', permission_request_hook),
+            # Issue #3 — closes the last gap, brings SDK-supported hook
+            # coverage to 10/10.
+            ('SubagentStart', subagent_start_hook),
+            ('SubagentStop', subagent_stop_hook),
         )
         for event, callback in events_to_callbacks:
             hooks.setdefault(event, [])
@@ -995,9 +1098,15 @@ class _ConversationState:
         root_span: LogfireSpan,
         input_messages: list[ChatMessage],
         system_instructions: list[TextPart] | None = None,
+        options: Any = None,
     ) -> None:
         self.logfire = logfire
         self.root_span = root_span
+        # Issue #3: ``ClaudeAgentOptions`` reference kept so the subagent
+        # helper can look up the matching ``AgentDefinition`` at
+        # ``SubagentStart`` time (the hook input only carries ``agent_type``;
+        # the full definition lives in ``options.agents[agent_type]``).
+        self.options = options
         self.active_tool_spans: dict[str, LogfireSpan] = {}
         # Tool input as seen by ``pre_tool_use_hook`` keyed by ``tool_use_id``.
         # ``post_tool_use_hook`` consumes it to detect updatedInput mutations
@@ -1016,6 +1125,14 @@ class _ConversationState:
         self.compact_count = 0
         self.notification_count = 0
         self.permission_request_count = 0
+        # Subagent state (issue #3). One open span per active subagent,
+        # keyed by ``agent_id`` (SDK-generated, opaque). Tool-lifecycle
+        # hooks fired with ``agent_id`` look up the corresponding span
+        # here to re-parent the ``execute_tool`` span. Cleared on
+        # ``SubagentStop``; orphan spans (missing Stop) get ``state.close()``
+        # treatment.
+        self.subagent_spans: dict[str, LogfireSpan] = {}
+        self.subagent_count = 0
 
     def add_tool_result(self, tool_use_id: str, tool_name: str, result: Any) -> None:
         """Record a tool result to include in the next chat span's input messages."""
@@ -1147,10 +1264,16 @@ class _ConversationState:
             (self.compact_count, CLAUDE_COMPACT_COUNT),
             (self.notification_count, CLAUDE_NOTIFICATION_COUNT),
             (self.permission_request_count, CLAUDE_PERMISSION_REQUEST_COUNT),
+            (self.subagent_count, CLAUDE_SUBAGENT_COUNT),
         )
         for value, attr in counter_map:
             if value:
                 self.root_span.set_attribute(attr, value)
+        # Close any orphan subagent spans (missing ``SubagentStop`` due to
+        # session abort, error, etc.). Issue #3.
+        for span in self.subagent_spans.values():
+            span._end()  # pyright: ignore[reportPrivateUsage]
+        self.subagent_spans.clear()
         for span in self.active_tool_spans.values():
             span._end()  # pyright: ignore[reportPrivateUsage]
         self.active_tool_spans.clear()
@@ -1534,3 +1657,242 @@ def _wrap_can_use_tool(callback: Any) -> Any:
 
     wrapped._logfire_wrapped = True  # type: ignore[attr-defined]
     return wrapped
+
+
+# ---------------------------------------------------------------------------
+# Subagent / Task* helpers (issue #3).
+#
+# Subagent lifecycle is paired ``SubagentStart`` → ``SubagentStop`` keyed by
+# ``agent_id``; the open ``subagent <agent_type>`` span lives in
+# ``state.subagent_spans`` so the tool-lifecycle hooks can re-parent
+# ``execute_tool`` spans onto it via ``_tool_parent_otel_span``.
+#
+# Task* SystemMessage subclasses arrive in the dispatch loop. The Task tool
+# itself surfaces in current SDK versions as ``execute_tool Agent`` (older
+# versions: ``execute_tool Task``); Task* messages carry a ``tool_use_id``
+# that correlates back to that span if needed downstream.
+# ---------------------------------------------------------------------------
+
+
+def _record_subagent_start(state: _ConversationState, input_data: Any) -> None:
+    """Open a ``subagent <agent_type>`` span and register it under ``agent_id``.
+
+    Sibling of ``execute_tool Agent`` (the parent's view of the Task tool)
+    rather than nested — ``SubagentStartHookInput`` carries no
+    ``tool_use_id`` so we can't reliably correlate to the right
+    ``execute_tool`` span without ordering heuristics.
+
+    Also captures the matching ``AgentDefinition`` metadata
+    (``model`` / ``description`` / ``tools`` / ``system_prompt`` etc.)
+    when ``options.agents[agent_type]`` is set — gives dashboards a way
+    to group subagents by configured model and audit the system prompt
+    that was in effect, without requiring a separate join.
+    """
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    agent_id = input_data.get('agent_id')
+    agent_type = input_data.get('agent_type') or ''
+    if not agent_id:  # pragma: no cover  # shouldn't happen — both are required by SDK type
+        return
+    # Increment AFTER the validation guards — a malformed event that
+    # bails before opening the span shouldn't bump the count.
+    state.subagent_count += 1
+
+    attrs: dict[str, Any] = {
+        AGENT_NAME: agent_type,
+        CLAUDE_AGENT_ID: agent_id,
+        CLAUDE_AGENT_TYPE: agent_type,
+        **_hook_session_id(input_data),
+        **_subagent_definition_attrs(state.options, agent_type),
+    }
+
+    # Open the span under the active OTel context (which is the root
+    # ``invoke_agent`` thanks to ``_run_hook``'s ``_attach_root_context``).
+    # Explicit ``'subagent {agent_type}'`` template (rather than an
+    # f-string) matches the ``Hook: PreCompact ({trigger})`` /
+    # ``Hook: PermissionResult ({behavior})`` precedent and avoids
+    # logfire's f-string introspection auto-extracting a bare
+    # ``agent_type`` attribute alongside the namespaced ``claude.agent_type``.
+    span = state.logfire.span('subagent {agent_type}', agent_type=agent_type, **attrs)
+    span._start()  # pyright: ignore[reportPrivateUsage]
+    state.subagent_spans[agent_id] = span
+
+
+def _subagent_definition_attrs(options: Any, agent_type: str) -> dict[str, Any]:
+    """Extract ``AgentDefinition`` metadata for the ``subagent`` span (issue #3).
+
+    Mirrors the ``_options_attrs`` precedent from #8: defensive
+    ``isinstance`` guard on ``options`` itself so duck-typed mocks don't
+    ship garbage; ``isinstance`` guard on the per-agent definition so
+    SimpleNamespace-shaped fakes are rejected; only emits fields that are
+    explicitly set.
+
+    AgentDefinition fields captured (8 of 13 SDK fields):
+      * ``description`` / ``prompt`` (→ ``claude.agent.system_prompt``) /
+        ``initialPrompt`` / ``model`` / ``memory`` / ``background`` —
+        scalars under ``claude.agent.*``.
+      * ``tools`` / ``disallowedTools`` / ``skills`` — lists, emitted
+        when non-empty.
+      * ``permissionMode`` / ``maxTurns`` / ``effort`` — reuse the
+        existing ``CLAUDE_PERMISSION_MODE`` / ``CLAUDE_MAX_TURNS`` /
+        ``CLAUDE_EFFORT`` constants from #8 (same configuration concepts;
+        span_name distinguishes parent-options from subagent-definition
+        in dashboards).
+
+    Deferred:
+      * ``mcpServers`` — potentially-large nested config dict; needs its
+        own extractor with name-only / structure-only modes.
+
+    Returns ``{}`` when ``options`` is None or not a recognisable
+    ``ClaudeAgentOptions``, when ``options.agents`` isn't a dict, or when
+    ``agents[agent_type]`` isn't a recognisable ``AgentDefinition``.
+    """
+    if options is None or not isinstance(options, claude_agent_sdk.ClaudeAgentOptions):
+        return {}
+    agents = getattr(options, 'agents', None)
+    if not isinstance(agents, dict):
+        return {}
+    definition = agents.get(agent_type)
+    AgentDefinition = getattr(claude_agent_sdk, 'AgentDefinition', None)
+    if AgentDefinition is None or not isinstance(definition, AgentDefinition):
+        return {}
+
+    attrs: dict[str, Any] = {}
+    # Map AgentDefinition field → semconv constant. Note SDK's camelCase
+    # field names (``disallowedTools`` / ``initialPrompt`` / ``maxTurns`` /
+    # ``permissionMode``) — accessed via ``getattr`` since Python attribute
+    # lookup is case-sensitive. Surface under snake_case ``claude.*`` attrs.
+    scalar_map: tuple[tuple[str, str], ...] = (
+        ('model', CLAUDE_AGENT_MODEL),
+        ('description', CLAUDE_AGENT_DESCRIPTION),
+        ('prompt', CLAUDE_AGENT_SYSTEM_PROMPT),
+        ('initialPrompt', CLAUDE_AGENT_INITIAL_PROMPT),
+        ('memory', CLAUDE_AGENT_MEMORY),
+        ('background', CLAUDE_AGENT_BACKGROUND),
+        # Re-use of #8's constants: same configuration concepts.
+        ('permissionMode', CLAUDE_PERMISSION_MODE),
+        ('maxTurns', CLAUDE_MAX_TURNS),
+        ('effort', CLAUDE_EFFORT),
+    )
+    for src, dst in scalar_map:
+        if (value := getattr(definition, src, None)) is not None:
+            attrs[dst] = value
+    # Lists — emit when non-empty.
+    list_map: tuple[tuple[str, str], ...] = (
+        ('tools', CLAUDE_AGENT_TOOLS),
+        ('disallowedTools', CLAUDE_AGENT_DISALLOWED_TOOLS),
+        ('skills', CLAUDE_AGENT_SKILLS),
+    )
+    for src, dst in list_map:
+        if value := getattr(definition, src, None):
+            attrs[dst] = list(value)
+    return attrs
+
+
+def _record_subagent_stop(state: _ConversationState, input_data: Any) -> None:
+    """Close the matching ``subagent`` span (issue #3).
+
+    The span envelope is the event record; no separate log is emitted.
+    See ``subagent_stop_hook``'s docstring for rationale.
+
+    Captures the undocumented-but-on-the-wire ``last_assistant_message``
+    field defensively — same forward-compat pattern as the regular ``Stop``
+    hook from #9.
+    """
+    if not isinstance(input_data, dict):  # pragma: no cover
+        return
+    agent_id = input_data.get('agent_id')
+    if not agent_id:  # pragma: no cover
+        return
+
+    span = state.subagent_spans.pop(agent_id, None)
+    last_assistant_message = input_data.get('last_assistant_message')
+    transcript_path = input_data.get('agent_transcript_path')
+
+    if span is not None:
+        if last_assistant_message is not None:
+            span.set_attribute(CLAUDE_SUBAGENT_LAST_ASSISTANT_MESSAGE, last_assistant_message)
+        if transcript_path is not None:
+            span.set_attribute(CLAUDE_AGENT_TRANSCRIPT_PATH, str(transcript_path))
+        span._end()  # pyright: ignore[reportPrivateUsage]
+
+
+def _record_task_started(state: _ConversationState, msg: Any) -> None:
+    """Record a ``TaskStartedMessage`` as an info log under the active span.
+
+    Carries the parent's ``tool_use_id`` (the Task tool call's id) so
+    downstream queries can join Task lifecycle events to the parent's
+    ``execute_tool`` span via ``gen_ai.tool.call.id``.
+    """
+    attrs = _msg_attrs(msg, (
+        ('task_id', CLAUDE_TASK_ID),
+        ('description', CLAUDE_TASK_DESCRIPTION),
+        ('task_type', CLAUDE_TASK_TYPE),
+        ('tool_use_id', TOOL_CALL_ID),
+    ))
+    state.logfire.info('Task started', **attrs)
+
+
+def _record_task_progress(state: _ConversationState, msg: Any) -> None:
+    """Record a ``TaskProgressMessage`` as an info log.
+
+    Typically only fires for long-running / background subagents — foreground
+    subagents (e.g. fast Task dispatches that finish in milliseconds) skip
+    progress and go straight from start to notification.
+    """
+    attrs = _msg_attrs(msg, (
+        ('task_id', CLAUDE_TASK_ID),
+        ('description', CLAUDE_TASK_DESCRIPTION),
+        ('last_tool_name', CLAUDE_TASK_LAST_TOOL_NAME),
+        ('tool_use_id', TOOL_CALL_ID),
+        ('usage', CLAUDE_TASK_USAGE),
+    ))
+    state.logfire.info('Task progress', **attrs)
+
+
+def _record_task_notification(state: _ConversationState, msg: Any) -> None:
+    """Record a ``TaskNotificationMessage`` as a level-appropriate log.
+
+    ``status='completed'`` → info, ``'stopped'`` → warn, ``'failed'`` →
+    error. Carries the final ``summary`` and ``output_file`` plus optional
+    ``usage``. Does NOT escalate the parent ``invoke_agent`` span on
+    ``failed`` — the parent isn't logically failed, just the subagent;
+    operators can filter by ``claude.task.status`` for failure dashboards.
+    """
+    status = getattr(msg, 'status', None)
+    attrs = _msg_attrs(msg, (
+        ('task_id', CLAUDE_TASK_ID),
+        ('status', CLAUDE_TASK_STATUS),
+        ('summary', CLAUDE_TASK_SUMMARY),
+        ('output_file', CLAUDE_TASK_OUTPUT_FILE),
+        ('tool_use_id', TOOL_CALL_ID),
+        ('usage', CLAUDE_TASK_USAGE),
+    ))
+
+    log = state.logfire.info
+    if status == 'failed':
+        log = state.logfire.error
+    elif status == 'stopped':
+        log = state.logfire.warn
+    log('Task {status}', status=status or 'unknown', **attrs)
+
+
+def _msg_session_id(msg: Any) -> dict[str, Any]:
+    """Extract ``session_id`` from a Task* message dataclass under the OTel
+    semconv ``gen_ai.conversation.id`` key. Returns ``{}`` when absent so
+    callers can splat unconditionally.
+    """
+    sid = getattr(msg, 'session_id', None)
+    return {CONVERSATION_ID: sid} if sid else {}
+
+
+def _msg_attrs(msg: Any, field_map: tuple[tuple[str, str], ...]) -> dict[str, Any]:
+    """Build a Task* log attrs dict: session id seed plus every mapped field
+    that's set on ``msg`` (``is not None`` test so falsy-but-present values
+    like ``0`` survive).
+    """
+    attrs = _msg_session_id(msg)
+    for sdk_field, attr_name in field_map:
+        if (value := getattr(msg, sdk_field, None)) is not None:
+            attrs[attr_name] = value
+    return attrs

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -258,6 +258,73 @@ CLAUDE_MCP_SERVER_NAME = 'claude.mcp.server_name'
 CLAUDE_MCP_ENABLED = 'claude.mcp.enabled'
 CLAUDE_TASK_ID = 'claude.task_id'
 
+# Subagent / Task* attributes (issue #3). Surfaced on the
+# ``subagent <agent_type>`` span opened on ``SubagentStart`` and on logs
+# dispatched from ``TaskStartedMessage`` / ``TaskProgressMessage`` /
+# ``TaskNotificationMessage`` system-message events.
+#
+# SAFE_KEYS treatment (in scrubbing.py):
+#   * ``claude.subagent.last_assistant_message`` — model-generated final
+#     subagent text. Allowlisted: same shape as
+#     ``claude.stop.last_assistant_message`` (the parent-thread analogue),
+#     which is also allowlisted. Operators expect the verbatim text to
+#     survive default scrubbing, since pattern-based redaction would
+#     destroy model output content.
+#   * ``claude.task.summary`` — model-generated end-of-task summary.
+#     Allowlisted: same shape as ``claude.result.text`` (also allowlisted).
+#
+# NOT on SAFE_KEYS:
+#   * ``claude.task.description`` — caller-supplied prompt text from the
+#     parent's Task tool call (``ToolUseBlock.input.description``); default
+#     scrubbing is the safer privacy posture, mirroring ``claude.user_prompt``.
+#   * ``claude.agent.transcript_path`` — filesystem path that may match
+#     ``auth``/``secret``/``private_key`` patterns; default scrub correct.
+#   * Other fields are short identifiers / enums / int dicts where scrubbing
+#     is a no-op or near-no-op.
+CLAUDE_TASK_DESCRIPTION = 'claude.task.description'
+CLAUDE_TASK_TYPE = 'claude.task.type'
+CLAUDE_TASK_STATUS = 'claude.task.status'
+CLAUDE_TASK_SUMMARY = 'claude.task.summary'
+CLAUDE_TASK_OUTPUT_FILE = 'claude.task.output_file'
+CLAUDE_TASK_USAGE = 'claude.task.usage'
+CLAUDE_TASK_LAST_TOOL_NAME = 'claude.task.last_tool_name'
+CLAUDE_AGENT_TRANSCRIPT_PATH = 'claude.agent.transcript_path'
+# ``last_assistant_message`` is on the wire on ``SubagentStop`` events
+# but NOT in the SDK's ``SubagentStopHookInput`` type — captured
+# defensively via ``.get()`` (mirrors ``claude.stop.last_assistant_message``
+# from #9).
+CLAUDE_SUBAGENT_LAST_ASSISTANT_MESSAGE = 'claude.subagent.last_assistant_message'
+# Cumulative subagent count emitted on the root invoke_agent at close.
+CLAUDE_SUBAGENT_COUNT = 'claude.subagent_count'
+
+# ``AgentDefinition`` metadata captured on the subagent span at
+# ``SubagentStart`` time (issue #3, Option B). Mirrors the
+# ``_options_attrs`` pattern from #8 — looked up via
+# ``options.agents[agent_type]``. Without this, the subagent span shows
+# only ``agent_id`` / ``agent_type`` / transcript path; with it, dashboards
+# can group / filter by which subagent model / tool allowlist is in use,
+# and the system prompt is queryable for audit.
+CLAUDE_AGENT_MODEL = 'claude.agent.model'
+CLAUDE_AGENT_DESCRIPTION = 'claude.agent.description'
+CLAUDE_AGENT_TOOLS = 'claude.agent.tools'
+CLAUDE_AGENT_DISALLOWED_TOOLS = 'claude.agent.disallowed_tools'
+CLAUDE_AGENT_SKILLS = 'claude.agent.skills'
+CLAUDE_AGENT_MEMORY = 'claude.agent.memory'
+CLAUDE_AGENT_BACKGROUND = 'claude.agent.background'
+# ``claude.agent.system_prompt`` and ``claude.agent.initial_prompt`` carry
+# operator-set guidance text. Both added to SAFE_KEYS — same rationale as
+# ``claude.compact.custom_instructions`` from #9: operator-controlled, not
+# user-runtime input.
+CLAUDE_AGENT_SYSTEM_PROMPT = 'claude.agent.system_prompt'
+CLAUDE_AGENT_INITIAL_PROMPT = 'claude.agent.initial_prompt'
+# Note: ``AgentDefinition.permissionMode`` / ``maxTurns`` / ``effort`` are
+# captured under the existing ``CLAUDE_PERMISSION_MODE`` / ``CLAUDE_MAX_TURNS``
+# / ``CLAUDE_EFFORT`` constants from #8 — same configuration concepts;
+# span name (``invoke_agent`` vs ``subagent <agent_type>``) disambiguates
+# whether they're parent-options or subagent-definition values in dashboards.
+# ``mcpServers`` is deliberately not captured here: potentially large,
+# contains nested config dicts; deferred to a separate extractor.
+
 # Type definitions for message parts and messages
 
 

--- a/logfire/_internal/scrubbing.py
+++ b/logfire/_internal/scrubbing.py
@@ -184,6 +184,20 @@ class BaseScrubber(ABC):
         # ``claude.notification.*`` are deliberately *not* on this list.
         gen_ai_semconv.CLAUDE_COMPACT_INSTRUCTIONS,
         gen_ai_semconv.CLAUDE_STOP_LAST_ASSISTANT_MESSAGE,
+        # Issue #3:
+        # - ``AgentDefinition.prompt`` — operator-set guidance text. Same
+        #   rationale as ``claude.compact.custom_instructions`` above:
+        #   operator-controlled, not user-runtime input.
+        # - ``claude.subagent.last_assistant_message`` mirrors
+        #   ``claude.stop.last_assistant_message`` directly (same source,
+        #   same shape: the verbatim final assistant text — just from the
+        #   subagent's perspective rather than the parent's).
+        # - ``claude.task.summary`` mirrors ``claude.result.text``: a
+        #   model-generated summary of the subagent run.
+        gen_ai_semconv.CLAUDE_AGENT_SYSTEM_PROMPT,
+        gen_ai_semconv.CLAUDE_AGENT_INITIAL_PROMPT,
+        gen_ai_semconv.CLAUDE_SUBAGENT_LAST_ASSISTANT_MESSAGE,
+        gen_ai_semconv.CLAUDE_TASK_SUMMARY,
     }
 
     @abstractmethod

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -27,6 +27,7 @@ import pytest
 pytest.importorskip('claude_agent_sdk', reason='claude_agent_sdk requires Python 3.10+')
 
 from claude_agent_sdk import (
+    AgentDefinition,
     AssistantMessage,
     ClaudeAgentOptions,
     ClaudeSDKClient,
@@ -62,8 +63,15 @@ from logfire._internal.integrations.claude_agent_sdk import (
     _record_rate_limit_event,
     _record_result,
     _record_stop,
+    _record_subagent_start,
+    _record_subagent_stop,
+    _record_task_notification,
+    _record_task_progress,
+    _record_task_started,
     _record_user_prompt_submit,
     _set_state,
+    _subagent_definition_attrs,
+    _tool_parent_otel_span,
     _wrap_can_use_tool,
     notification_hook,
     permission_request_hook,
@@ -1021,6 +1029,10 @@ def test_inject_hooks_none_hooks() -> None:
         'PreCompact',
         'Notification',
         'PermissionRequest',
+        # Issue #3 — closes the last gap, brings SDK-supported hook
+        # coverage to 10/10.
+        'SubagentStart',
+        'SubagentStop',
     }
     assert set(options.hooks) == expected_events
     for event in expected_events:
@@ -1046,7 +1058,10 @@ def test_inject_hooks_with_existing_events() -> None:
     assert options.hooks['PreToolUse'][1] is existing_hook
     # New non-tool-lifecycle events are added too, even though Opts didn't
     # declare them.
-    for event in ('UserPromptSubmit', 'Stop', 'PreCompact', 'Notification', 'PermissionRequest'):
+    for event in (
+        'UserPromptSubmit', 'Stop', 'PreCompact', 'Notification',
+        'PermissionRequest', 'SubagentStart', 'SubagentStop',
+    ):
         assert event in options.hooks
         assert len(options.hooks[event]) == 1
 
@@ -1999,6 +2014,577 @@ def test_all_lifecycle_and_control_methods_are_wrapped() -> None:
     ):
         fn = getattr(cls, name)
         assert getattr(fn, '__wrapped__', None) is not None, f'{name} should be wrapped'
+
+
+# ---------------------------------------------------------------------------
+# Subagent / Task* tests (issue #3).
+#
+# Three layers locked in this block:
+# 1. ``SubagentStart`` opens a ``subagent <agent_type>`` span keyed by
+#    ``agent_id`` (with optional ``AgentDefinition`` metadata when
+#    ``options.agents[agent_type]`` is configured); ``SubagentStop``
+#    closes it and captures ``last_assistant_message`` + transcript path.
+# 2. ``execute_tool`` spans re-parent under the subagent span when the
+#    PreToolUse hook input carries ``agent_id``.
+# 3. ``TaskStartedMessage`` / ``TaskProgressMessage`` /
+#    ``TaskNotificationMessage`` dispatch as level-appropriate logs.
+#
+# Plus the parallel-subagent disambiguation case — three concurrent
+# subagents with interleaved tool calls all parent correctly via
+# ``state.subagent_spans`` keyed by ``agent_id``.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_record_subagent_start_opens_span_keyed_by_agent_id(exporter: TestExporter) -> None:
+    """``SubagentStart`` → opens ``subagent <agent_type>`` span, registers it
+    in ``state.subagent_spans[agent_id]``, increments ``subagent_count``.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_subagent_start(
+            state,
+            {
+                'session_id': 'sess-xyz',
+                'agent_id': 'agent_A_id',
+                'agent_type': 'echo-helper',
+            },
+        )
+        assert state.subagent_count == 1
+        assert 'agent_A_id' in state.subagent_spans
+        # Close so the span end_time is set before snapshot inspection.
+        _record_subagent_stop(state, {'agent_id': 'agent_A_id', 'agent_type': 'echo-helper'})
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    sub = next(s for s in spans if s['name'] == 'subagent {agent_type}')
+    assert sub['attributes']['claude.agent_id'] == 'agent_A_id'
+    assert sub['attributes']['claude.agent_type'] == 'echo-helper'
+    assert sub['attributes']['gen_ai.agent.name'] == 'echo-helper'
+    assert sub['attributes']['gen_ai.conversation.id'] == 'sess-xyz'
+
+
+@pytest.mark.anyio
+async def test_record_subagent_stop_captures_last_assistant_message_and_transcript(exporter: TestExporter) -> None:
+    """``SubagentStop`` closes the span and captures the verbatim
+    ``last_assistant_message`` (undocumented wire field, mirrors the
+    regular ``Stop`` hook from #9) plus ``agent_transcript_path``."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_subagent_start(state, {'agent_id': 'agent_X', 'agent_type': 'reviewer'})
+        _record_subagent_stop(
+            state,
+            {
+                'agent_id': 'agent_X',
+                'agent_type': 'reviewer',
+                'last_assistant_message': 'review complete: looks good',
+                'agent_transcript_path': '/tmp/.claude/subagents/agent-X.jsonl',
+            },
+        )
+        # Span popped from active dict.
+        assert 'agent_X' not in state.subagent_spans
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    sub = next(s for s in spans if s['name'] == 'subagent {agent_type}')
+    assert sub['attributes']['claude.subagent.last_assistant_message'] == 'review complete: looks good'
+    assert sub['attributes']['claude.agent.transcript_path'] == '/tmp/.claude/subagents/agent-X.jsonl'
+
+
+@pytest.mark.anyio
+async def test_record_subagent_stop_no_open_span_emits_no_crash(exporter: TestExporter) -> None:
+    """Defensive: ``SubagentStop`` arriving without a matching ``Start``
+    (e.g. SDK bug, message-stream out-of-order) is a no-op rather than a
+    crash."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        # No matching Start. Must not raise.
+        _record_subagent_stop(state, {'agent_id': 'orphan_agent', 'agent_type': 'whatever'})
+    # Nothing additional in the export beyond the root invoke_agent.
+
+
+@pytest.mark.anyio
+async def test_subagent_definition_attrs_full_capture() -> None:
+    """``_subagent_definition_attrs`` extracts ``AgentDefinition`` metadata
+    from ``options.agents[agent_type]`` for the subagent span (issue #3,
+    Option B). Mirrors the ``_options_attrs`` pattern from #8 — defensive
+    ``isinstance`` guard, optional-field skip, list-when-non-empty."""
+    options = ClaudeAgentOptions(
+        agents={
+            'reviewer': AgentDefinition(
+                description='Reviews code changes for safety.',
+                prompt='You are a careful reviewer.',
+                tools=['Read', 'Grep'],
+                disallowedTools=['Bash'],
+                model='haiku',
+                skills=['code-review'],
+                memory='project',
+            ),
+        },
+    )
+    attrs = _subagent_definition_attrs(options, 'reviewer')
+    assert attrs == {
+        'claude.agent.description': 'Reviews code changes for safety.',
+        'claude.agent.system_prompt': 'You are a careful reviewer.',
+        'claude.agent.model': 'haiku',
+        'claude.agent.memory': 'project',
+        'claude.agent.tools': ['Read', 'Grep'],
+        'claude.agent.disallowed_tools': ['Bash'],
+        'claude.agent.skills': ['code-review'],
+    }
+
+
+def test_subagent_definition_attrs_returns_empty_for_missing_or_invalid() -> None:
+    """The lookup is best-effort: returns ``{}`` when options is None,
+    when ``agents`` isn't a dict, when the agent_type isn't in the map,
+    or when the value isn't a recognisable ``AgentDefinition`` (duck-typed
+    mocks). Never crashes."""
+    # No options.
+    assert _subagent_definition_attrs(None, 'reviewer') == {}
+
+    # options.agents is None.
+    options_no_agents = ClaudeAgentOptions()
+    assert _subagent_definition_attrs(options_no_agents, 'reviewer') == {}
+
+    # options.agents is a dict but agent_type not in it.
+    options_with_agents = ClaudeAgentOptions(
+        agents={'other': AgentDefinition(description='x', prompt='y')},
+    )
+    assert _subagent_definition_attrs(options_with_agents, 'reviewer') == {}
+
+    # Defensive: SimpleNamespace mock with the right shape — gets rejected
+    # by the isinstance guard so we don't ship garbage attribute values.
+    class FakeOpts:
+        agents = {'reviewer': SimpleNamespace(model='haiku', description='fake')}
+
+    assert _subagent_definition_attrs(FakeOpts(), 'reviewer') == {}
+
+
+@pytest.mark.anyio
+async def test_record_subagent_start_pulls_agent_definition_when_set(exporter: TestExporter) -> None:
+    """End-to-end: ``_record_subagent_start`` looks up
+    ``options.agents[agent_type]`` via ``state.options`` and surfaces the
+    ``AgentDefinition`` metadata on the subagent span. Without options,
+    only the basic identity attrs land."""
+    options = ClaudeAgentOptions(
+        agents={
+            'echo-helper': AgentDefinition(
+                description='Trivial echo helper',
+                prompt='Echo what you receive',
+                tools=['Bash'],
+                model='haiku',
+            ),
+        },
+    )
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(
+            logfire=logfire_instance,
+            root_span=root,
+            input_messages=[],
+            options=options,
+        )
+        _record_subagent_start(state, {'agent_id': 'a1', 'agent_type': 'echo-helper'})
+        _record_subagent_stop(state, {'agent_id': 'a1', 'agent_type': 'echo-helper'})
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    sub = next(s for s in spans if s['name'] == 'subagent {agent_type}')
+    assert sub['attributes']['claude.agent.model'] == 'haiku'
+    assert sub['attributes']['claude.agent.description'] == 'Trivial echo helper'
+    assert sub['attributes']['claude.agent.system_prompt'] == 'Echo what you receive'
+    assert sub['attributes']['claude.agent.tools'] == ['Bash']
+
+
+@pytest.mark.anyio
+async def test_tool_parent_otel_span_picks_subagent_when_agent_id_present(exporter: TestExporter) -> None:
+    """Locks the issue-#3 re-parent contract: when ``input_data`` carries
+    ``agent_id`` AND ``state.subagent_spans`` has a span for it,
+    ``_tool_parent_otel_span`` returns the subagent's OTel span (so the
+    next ``execute_tool`` parents under it). Otherwise → root.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_subagent_start(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
+
+        # Subagent context — should return subagent's OTel span.
+        sub_otel = _tool_parent_otel_span(state, {'agent_id': 'agent_A', 'tool_name': 'Bash'})
+        assert sub_otel is not None
+        assert sub_otel is state.subagent_spans['agent_A']._span  # type: ignore[attr-defined]
+
+        # No agent_id — main thread; should return root.
+        root_otel = _tool_parent_otel_span(state, {'tool_name': 'Bash'})
+        assert root_otel is state.root_span._span  # type: ignore[attr-defined]
+
+        # agent_id present but no matching subagent span (defensive) → root.
+        unknown = _tool_parent_otel_span(state, {'agent_id': 'unknown_agent', 'tool_name': 'Bash'})
+        assert unknown is state.root_span._span  # type: ignore[attr-defined]
+
+        _record_subagent_stop(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
+
+
+@pytest.mark.anyio
+async def test_pre_tool_use_hook_reparents_under_subagent_when_agent_id_set(exporter: TestExporter) -> None:
+    """End-to-end via the public hook callbacks: when ``pre_tool_use_hook``
+    fires with ``agent_id`` in the input dict (the SDK marks tool calls
+    originating inside a subagent context this way), the resulting
+    ``execute_tool`` span has the subagent span as its parent — not the
+    root ``invoke_agent``. Locks the most subtle invariant of #3."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    ctx: HookContext = {'signal': None}
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            # Open subagent span first (mimics SubagentStart firing).
+            _record_subagent_start(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
+
+            # Now a tool call from inside the subagent.
+            await pre_tool_use_hook(
+                {
+                    'tool_name': 'Bash',
+                    'tool_input': {'command': 'ls'},
+                    'tool_use_id': 'tu_sub_1',
+                    'agent_id': 'agent_A',
+                    'agent_type': 'helper',
+                },
+                'tu_sub_1',
+                ctx,
+            )
+            await post_tool_use_hook(
+                {
+                    'tool_name': 'Bash',
+                    'tool_input': {'command': 'ls'},
+                    'tool_response': 'file1\n',
+                    'tool_use_id': 'tu_sub_1',
+                    'agent_id': 'agent_A',
+                    'agent_type': 'helper',
+                },
+                'tu_sub_1',
+                ctx,
+            )
+
+            _record_subagent_stop(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    tool_span = next(s for s in spans if s['name'] == 'execute_tool Bash')
+    sub_span = next(s for s in spans if s['name'] == 'subagent {agent_type}')
+    # Tool span's parent IS the subagent span (not the root invoke_agent).
+    assert tool_span['parent']['span_id'] == sub_span['context']['span_id']
+
+
+@pytest.mark.anyio
+async def test_pre_tool_use_hook_parents_under_root_when_no_agent_id(exporter: TestExporter) -> None:
+    """Symmetric check: a normal (non-subagent) tool call still parents
+    under the root ``invoke_agent``. Catches a regression where
+    ``_tool_parent_otel_span`` accidentally always selects a subagent
+    span (e.g. due to stale state)."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    ctx: HookContext = {'signal': None}
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            # Open and close a subagent span — it should NOT influence
+            # subsequent root-thread tool calls.
+            _record_subagent_start(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
+            _record_subagent_stop(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
+
+            # Tool call from the main thread (no agent_id).
+            await pre_tool_use_hook(
+                {'tool_name': 'Bash', 'tool_input': {'command': 'ls'}, 'tool_use_id': 'tu_root_1'},
+                'tu_root_1',
+                ctx,
+            )
+            await post_tool_use_hook(
+                {
+                    'tool_name': 'Bash',
+                    'tool_input': {'command': 'ls'},
+                    'tool_response': 'ok',
+                    'tool_use_id': 'tu_root_1',
+                },
+                'tu_root_1',
+                ctx,
+            )
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    tool_span = next(s for s in spans if s['name'] == 'execute_tool Bash')
+    root_span = next(s for s in spans if s['name'] == 'invoke_agent')
+    assert tool_span['parent']['span_id'] == root_span['context']['span_id']
+
+
+@pytest.mark.anyio
+async def test_three_parallel_subagents_each_tool_lands_under_correct_span(exporter: TestExporter) -> None:
+    """**The parallel-subagent correctness lock.** Three concurrent
+    subagents (A, B, C) with interleaved tool calls. Each subagent's
+    tool-lifecycle hook fires with its own ``agent_id`` — the
+    ``_tool_parent_otel_span`` lookup keys by agent_id and parents the
+    ``execute_tool`` span under the right subagent.
+
+    SubagentStart / SubagentStop ordering simulates real interleaving
+    (B starts last but finishes first, etc.) to catch any state-machine
+    assumption that subagents complete in-order.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    ctx: HookContext = {'signal': None}
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            # Three SubagentStart events (parent dispatched 3 Tasks).
+            _record_subagent_start(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
+            _record_subagent_start(state, {'agent_id': 'B_id', 'agent_type': 'planner'})
+            _record_subagent_start(state, {'agent_id': 'C_id', 'agent_type': 'reviewer'})  # same type as A
+
+            # All three subagent spans are open simultaneously.
+            assert set(state.subagent_spans) == {'A_id', 'B_id', 'C_id'}
+
+            # Interleaved tool calls — each carries its own agent_id.
+            await pre_tool_use_hook(
+                {'tool_name': 'Read', 'tool_input': {}, 'tool_use_id': 'tu_A1', 'agent_id': 'A_id'},
+                'tu_A1', ctx,
+            )
+            await pre_tool_use_hook(
+                {'tool_name': 'Bash', 'tool_input': {}, 'tool_use_id': 'tu_C1', 'agent_id': 'C_id'},
+                'tu_C1', ctx,
+            )
+            await pre_tool_use_hook(
+                {'tool_name': 'Grep', 'tool_input': {}, 'tool_use_id': 'tu_B1', 'agent_id': 'B_id'},
+                'tu_B1', ctx,
+            )
+            # Posts in different order from pre.
+            await post_tool_use_hook(
+                {'tool_name': 'Bash', 'tool_input': {}, 'tool_response': 'x', 'tool_use_id': 'tu_C1', 'agent_id': 'C_id'},
+                'tu_C1', ctx,
+            )
+            await post_tool_use_hook(
+                {'tool_name': 'Read', 'tool_input': {}, 'tool_response': 'x', 'tool_use_id': 'tu_A1', 'agent_id': 'A_id'},
+                'tu_A1', ctx,
+            )
+            await post_tool_use_hook(
+                {'tool_name': 'Grep', 'tool_input': {}, 'tool_response': 'x', 'tool_use_id': 'tu_B1', 'agent_id': 'B_id'},
+                'tu_B1', ctx,
+            )
+
+            # Stops in different order from starts (B finishes first, then A, then C).
+            _record_subagent_stop(state, {'agent_id': 'B_id', 'agent_type': 'planner'})
+            _record_subagent_stop(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
+            _record_subagent_stop(state, {'agent_id': 'C_id', 'agent_type': 'reviewer'})
+
+            # All cleanly closed.
+            assert state.subagent_spans == {}
+            assert state.subagent_count == 3
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    # Two subagent spans of type 'reviewer' (A and C) and one 'planner' (B).
+    sub_spans = [s for s in spans if s['name'] == 'subagent {agent_type}']
+    assert len(sub_spans) == 3
+    by_agent_id = {s['attributes']['claude.agent_id']: s for s in sub_spans}
+    assert set(by_agent_id) == {'A_id', 'B_id', 'C_id'}
+
+    # The disambiguator: each tool span's parent is its subagent's span,
+    # NOT a sibling subagent's, NOT the root.
+    tool_spans = [s for s in spans if s['name'].startswith('execute_tool ')]
+    parent_by_tool_id = {s['attributes']['gen_ai.tool.call.id']: s['parent']['span_id'] for s in tool_spans}
+    assert parent_by_tool_id['tu_A1'] == by_agent_id['A_id']['context']['span_id']
+    assert parent_by_tool_id['tu_B1'] == by_agent_id['B_id']['context']['span_id']
+    assert parent_by_tool_id['tu_C1'] == by_agent_id['C_id']['context']['span_id']
+
+
+@pytest.mark.anyio
+async def test_state_close_ends_orphan_subagent_spans(exporter: TestExporter) -> None:
+    """If a subagent's ``Start`` fires but ``Stop`` never does (session
+    abort, error mid-conversation), ``state.close()`` must end the
+    orphan span so it doesn't leak open until process exit. Also clears
+    ``subagent_spans``."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_subagent_start(state, {'agent_id': 'orphan_A', 'agent_type': 'helper'})
+        _record_subagent_start(state, {'agent_id': 'orphan_B', 'agent_type': 'helper'})
+        # Neither receives a Stop — simulate aborted session.
+        state.close()
+        assert state.subagent_spans == {}
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    orphans = [s for s in spans if s['name'] == 'subagent {agent_type}']
+    assert len(orphans) == 2
+    # Both have end_time set (closed by state.close, not still open).
+    # ``exporter.exported_spans_as_dict`` only includes finished spans, so
+    # presence here is the proof.
+
+
+@pytest.mark.anyio
+async def test_state_close_emits_subagent_count_when_nonzero(exporter: TestExporter) -> None:
+    """``claude.subagent_count`` lands on the root span at close, mirroring
+    the other counter aggregates from #9. Skipped when zero (happy-path
+    sessions don't carry an always-zero attribute)."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_subagent_start(state, {'agent_id': 'A', 'agent_type': 'helper'})
+        _record_subagent_stop(state, {'agent_id': 'A', 'agent_type': 'helper'})
+        _record_subagent_start(state, {'agent_id': 'B', 'agent_type': 'helper'})
+        _record_subagent_stop(state, {'agent_id': 'B', 'agent_type': 'helper'})
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    assert root_attrs['claude.subagent_count'] == 2
+
+
+@pytest.mark.anyio
+async def test_state_close_skips_zero_subagent_count(exporter: TestExporter) -> None:
+    """No subagents fired → no ``claude.subagent_count`` on root."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        state.close()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    root_attrs = next(s for s in spans if s['name'] == 'invoke_agent')['attributes']
+    assert 'claude.subagent_count' not in root_attrs
+
+
+@pytest.mark.anyio
+async def test_record_task_started_emits_info_log_with_correlation_attrs(exporter: TestExporter) -> None:
+    """``TaskStartedMessage`` → info log with ``claude.task_id``,
+    ``claude.task.description``, ``claude.task.type``, and the parent's
+    ``gen_ai.tool.call.id`` (the Task tool's id) for cross-span correlation."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        msg = SimpleNamespace(
+            task_id='task_001',
+            description='Echo a phrase via Bash',
+            uuid='uuid-task-1',
+            session_id='sess-x',
+            tool_use_id='toolu_parent_call',
+            task_type='local_agent',
+        )
+        _record_task_started(state, msg)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Task started')
+    assert log['attributes']['claude.task_id'] == 'task_001'
+    assert log['attributes']['claude.task.description'] == 'Echo a phrase via Bash'
+    assert log['attributes']['claude.task.type'] == 'local_agent'
+    assert log['attributes']['gen_ai.tool.call.id'] == 'toolu_parent_call'
+    assert log['attributes']['gen_ai.conversation.id'] == 'sess-x'
+    assert log['attributes']['logfire.level_num'] == 9  # info
+
+
+@pytest.mark.anyio
+async def test_record_task_progress_emits_info_log_with_usage(exporter: TestExporter) -> None:
+    """``TaskProgressMessage`` → info log with ``claude.task.usage`` (the
+    full TaskUsage dict — total_tokens, tool_uses, duration_ms) and
+    ``claude.task.last_tool_name``."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        msg = SimpleNamespace(
+            task_id='task_002',
+            description='Long-running analysis',
+            usage={'total_tokens': 5000, 'tool_uses': 3, 'duration_ms': 12000},
+            uuid='uuid-task-2',
+            session_id='sess-y',
+            tool_use_id='toolu_parent_call_2',
+            last_tool_name='Bash',
+        )
+        _record_task_progress(state, msg)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Task progress')
+    assert log['attributes']['claude.task_id'] == 'task_002'
+    assert log['attributes']['claude.task.last_tool_name'] == 'Bash'
+    assert log['attributes']['claude.task.usage'] == {
+        'total_tokens': 5000,
+        'tool_uses': 3,
+        'duration_ms': 12000,
+    }
+    assert log['attributes']['logfire.level_num'] == 9  # info
+
+
+@pytest.mark.anyio
+async def test_record_task_notification_status_completed_is_info(exporter: TestExporter) -> None:
+    """``status='completed'`` → info level."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        msg = SimpleNamespace(
+            task_id='task_ok',
+            status='completed',
+            output_file='/tmp/task_ok.txt',
+            summary='Done',
+            uuid='u',
+            session_id='s',
+            tool_use_id='t',
+            usage=None,
+        )
+        _record_task_notification(state, msg)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Task {status}')
+    assert log['attributes']['claude.task.status'] == 'completed'
+    assert log['attributes']['claude.task.summary'] == 'Done'
+    assert log['attributes']['claude.task.output_file'] == '/tmp/task_ok.txt'
+    assert log['attributes']['logfire.level_num'] == 9  # info
+
+
+@pytest.mark.anyio
+async def test_record_task_notification_status_failed_is_error(exporter: TestExporter) -> None:
+    """``status='failed'`` → error level. Audit-relevant: subagent crashes
+    surface in error dashboards even when the parent recovers gracefully."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        msg = SimpleNamespace(
+            task_id='task_fail',
+            status='failed',
+            output_file='',
+            summary='subagent hit an internal error',
+            uuid='u',
+            session_id='s',
+            tool_use_id='t',
+            usage=None,
+        )
+        _record_task_notification(state, msg)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Task {status}')
+    assert log['attributes']['logfire.level_num'] == 17  # error
+
+
+@pytest.mark.anyio
+async def test_record_task_notification_status_stopped_is_warn(exporter: TestExporter) -> None:
+    """``status='stopped'`` → warn level. User-initiated cancellations
+    (via ``stop_task`` from #11) shouldn't be filed as errors but ARE
+    audit-relevant."""
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        msg = SimpleNamespace(
+            task_id='task_stop',
+            status='stopped',
+            output_file='',
+            summary='stopped by user',
+            uuid='u',
+            session_id='s',
+            tool_use_id='t',
+            usage=None,
+        )
+        _record_task_notification(state, msg)
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    log = next(s for s in spans if s['name'] == 'Task {status}')
+    assert log['attributes']['logfire.level_num'] == 13  # warn
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Closes #3. Recon: https://github.com/oneryalcin/logfire/issues/3#issuecomment-4320739440. Empirical baseline: https://github.com/oneryalcin/logfire/issues/3#issuecomment-4320760818. Verify: https://github.com/oneryalcin/logfire/issues/3#issuecomment-4320837142.

## Summary

Subagent invocations were a complete observability black hole pre-PR. The 2 ``SubagentStart`` / ``SubagentStop`` hooks were unregistered, the 3 ``Task*`` ``SystemMessage`` subclasses were dropped from the dispatch loop, and subagent tool calls flattened under the root ``invoke_agent`` with no ``agent_id`` distinction.

Three layers brought online:

1. **Subagent span lifecycle**: ``SubagentStart`` opens a ``subagent {agent_type}`` span keyed by ``agent_id``; ``SubagentStop`` closes it and captures the verbatim final assistant text (undocumented wire field, mirrors #9's ``Stop`` capture pattern).
2. **Tool-call re-parenting**: ``pre_tool_use_hook`` uses ``_tool_parent_otel_span(state, input_data)`` to look up ``state.subagent_spans[agent_id]`` and parent the ``execute_tool`` span under the subagent span instead of root. **Parallel subagents work by construction** — agent_id is the dict key, O(1) lookup, no contamination.
3. **Task* dispatch + AgentDefinition metadata** (Option B): 3 new dispatch branches plus full ``AgentDefinition`` capture for subagent model / system_prompt / tool allowlist / etc.

This brings **SDK-supported hook coverage to 10 of 10**. Remaining ``SessionStart`` / ``SessionEnd`` are CLI-schema-only and not exposed by the Python SDK; tracked in #22.

## Span shape

```
invoke_agent (root, parent thread)
├── chat claude-sonnet-4-6        (parent's turn)
├── execute_tool Agent            (parent's view of the Task tool — current SDK
│                                  surfaces 'Task' as 'Agent' in the SDK)
├── subagent echo-helper          (sibling of execute_tool Agent)
│   └── execute_tool Bash         (subagent's tool call, re-parented via agent_id)
├── Task started                  (log; info)
├── Task progress                 (log; only fires for tool-using or background subagents)
├── Task completed                (log; level depends on status)
└── chat claude-sonnet-4-6        (parent's continuation)
```

## SAFE_KEYS treatment (corrected after Opus P1)

3 new entries on the scrubber allowlist, all **model-generated text** (not user input — important distinction):

- ``claude.subagent.last_assistant_message`` — mirrors ``claude.stop.last_assistant_message`` (parent-thread analogue, also allowlisted).
- ``claude.task.summary`` — mirrors ``claude.result.text`` (also allowlisted).
- ``claude.agent.system_prompt`` / ``claude.agent.initial_prompt`` — operator-set guidance text; mirror ``claude.compact.custom_instructions``.

The original SAFE_KEYS rationale block in semconv.py mistakenly said the model-generated subagent text mirrored ``claude.user_prompt`` (user input); Opus caught the asymmetry — fixed.

## Parallel-subagent disambiguation

Three concurrent Task dispatches → three ``subagent`` spans open in ``state.subagent_spans`` keyed by ``agent_id``. Each subagent's tool calls find their own span via O(1) dict lookup. Two subagents of the **same** ``agent_type`` get distinct ``agent_id``s — span names match (``subagent echo-helper``) but ``claude.agent_id`` distinguishes them in dashboards.

Locked by ``test_three_parallel_subagents_each_tool_lands_under_correct_span``: 3 concurrent subagents (two of same type), interleaved tool calls, out-of-order Stops, asserts each ``execute_tool`` parent points at the right subagent span.

## AgentDefinition metadata (Option B)

When ``ClaudeAgentOptions.agents[agent_type]`` is configured, the subagent span carries 8 of 13 SDK fields:

- ``claude.agent.model`` — the configured subagent model (e.g. ``'haiku'`` — cost attribution win when different from parent's ``'sonnet'``)
- ``claude.agent.description`` / ``claude.agent.system_prompt`` (from ``AgentDefinition.prompt``, allowlisted) / ``claude.agent.initial_prompt`` (allowlisted) / ``claude.agent.memory`` / ``claude.agent.background``
- ``claude.agent.tools`` / ``claude.agent.disallowed_tools`` / ``claude.agent.skills`` (lists, when set)
- ``claude.permission_mode`` / ``claude.max_turns`` / ``claude.effort`` — re-using #8's constants since they're the same configuration concepts; ``span_name`` distinguishes parent-options from subagent-definition values in dashboards

Deferred: ``mcpServers`` (potentially-large nested config; needs its own extractor).

## Documented limitation: subagent chat spans flatten under invoke_agent

Subagent assistant turns produce ``chat`` spans flat under ``invoke_agent`` rather than nested under their parent ``subagent`` span. The dispatch loop's ``handle_assistant_message`` doesn't have ``agent_id`` available — only ``msg.parent_tool_use_id``. Cross-correlation still works via the ``claude.parent_tool_use_id`` attribute already captured on each chat span (#7), joined to the parent's ``execute_tool Agent`` span via ``gen_ai.tool.call.id``.

Fully nesting subagent chat spans is a state-machine refactor (per-subagent ``_current_span`` keyed by agent_id, counter scoping decisions, ``pydantic_ai.all_messages`` rendering re-think). **Filed as #26** to land with dedicated design + review attention rather than mixing into this PR.

## Empirical verification

``empirical/issue_03_subagents.py`` registers spy ``SubagentStart`` / ``SubagentStop`` callbacks plus a custom ``echo-helper`` ``AgentDefinition``, drives a real session that prompts the model to dispatch a subagent that uses Bash.

- **Pre-patch**: zero subagent observability. SubagentStart/Stop fire but produce no logfire signal. Task* messages dropped from dispatch. Subagent's Bash call flat under invoke_agent with no agent_id distinction.
- **Post-patch**: ``subagent`` span opens with ``last_assistant_message`` captured (verbatim ``'The output is: \`subagent-tool-call\`'``); ``execute_tool Bash`` re-parented under subagent; ``Task started`` / ``Task progress`` (with ``last_tool_name='Bash'``) / ``Task completed`` all dispatched; ``AgentDefinition`` metadata visible (``claude.agent.model='haiku'``, ``.system_prompt``, ``.description``, ``.tools=['Bash']``).

Live UI trace at ``service=issue-03-subagents`` (``discovering-cc`` project).

## Tests

19 new tests, all behavior locks (no snapshot diffs). Highlights:

- ``test_three_parallel_subagents_each_tool_lands_under_correct_span`` — the parallel-disambiguation lock.
- ``test_record_subagent_start_pulls_agent_definition_when_set`` — Option B end-to-end.
- ``test_subagent_definition_attrs_returns_empty_for_missing_or_invalid`` — defensive guards.
- ``test_state_close_ends_orphan_subagent_spans`` — orphan cleanup.
- ``test_record_task_notification_status_failed_is_error`` / ``test_record_task_notification_status_stopped_is_warn`` — level-mapping locks.
- ``test_pre_tool_use_hook_reparents_under_subagent_when_agent_id_set`` — main re-parent contract end-to-end.

Updated ``test_inject_hooks_none_hooks`` / ``test_inject_hooks_with_existing_events`` to assert all 10 events register a callback.

## Adversarial review

Three reviewers in parallel before commit:

- **Opus (P0/P1)**: 1 P1 caught (SAFE_KEYS asymmetry — fixed; ``claude.subagent.last_assistant_message`` and ``claude.task.summary`` now correctly mirror the parent-thread allowlisted analogues). 4 P2s applied: dead variable removed, stale function-name reference fixed, 5 missing AgentDefinition scalars added, counter-before-validation moved.
- **Sonnet (pattern compliance)**: 2 MUST FIX both addressed — docstring lies on ``subagent_stop_hook`` / ``_record_subagent_stop`` (claimed "emit a level-appropriate log"; the span envelope IS the event — rewrote docstrings) and user-facing docs (added). 4 SHOULD FIX applied: ``_run_hook`` count 5→7, ``_subagent_definition_attrs`` isinstance guard, f-string→template (eliminates bare un-namespaced ``agent_type`` attr).
- **code-simplifier**: factored ``_msg_attrs(msg, field_map)`` shared helper for the 3 ``_record_task_*`` helpers. **-2 net lines**.

## Test plan

- [x] ``92 passed`` in ``test_claude_agent_sdk.py``, 1 deselected (pre-existing flake on main).
- [x] ``test_secret_scrubbing`` — 12 passed (3 new SAFE_KEYS additions don't widen the allowlist beyond model-generated / operator-set text).
- [x] ``test_logfire_api`` — 3 passed, 1 skipped (no public-API change).
- [x] Empirical end-to-end through real Anthropic API + logfire UI: subagent span renders with all AgentDefinition metadata; ``execute_tool Bash`` visibly nested under subagent; Task* events all visible.