### PR TITLE
Re-parent subagent chat spans under the subagent envelope (#26)

### DIFF
--- a/docs/integrations/llms/claude-agent-sdk.md
+++ b/docs/integrations/llms/claude-agent-sdk.md
@@ -132,7 +132,7 @@ These spans are top-level (no `invoke_agent` parent) when called between turns; 
 
 ## Subagent observability
 
-When the Claude CLI spawns a subagent via the Task tool, the integration opens a `subagent {agent_type}` child span under `invoke_agent` keyed by `agent_id` (`SubagentStart` hook). The span closes on the matching `SubagentStop`, and tool calls fired inside the subagent context re-parent their `execute_tool` child spans under the subagent span rather than the root `invoke_agent`. The trace tree looks like:
+When the Claude CLI spawns a subagent via the Task tool, the integration opens a `subagent {agent_type}` child span under `invoke_agent` keyed by `agent_id` (`SubagentStart` hook). The span closes on the matching `SubagentStop`. Tool calls fired inside the subagent context re-parent their `execute_tool` child spans under the subagent span via `agent_id`, and per-turn `chat` spans emitted while the subagent is running re-parent under the subagent span via the `parent_tool_use_id` carried on subagent-originating `UserMessage` / `AssistantMessage` (issue #26). The trace tree looks like:
 
 ```
 invoke_agent                      (root, parent thread)
@@ -140,7 +140,9 @@ invoke_agent                      (root, parent thread)
 ├── execute_tool Agent            (parent's view of the Task tool — current SDK
 │                                  surfaces the Task tool as 'Agent')
 ├── subagent echo-helper          (sibling of execute_tool Agent)
-│   └── execute_tool Bash         (subagent's tool call, re-parented via agent_id)
+│   ├── chat claude-haiku-…       (subagent's per-turn chat span, nested via #26)
+│   ├── execute_tool Bash         (subagent's tool call, re-parented via agent_id)
+│   └── chat claude-haiku-…       (subagent's continuation after the tool result)
 ├── Task started                  (log under invoke_agent, info)
 ├── Task progress                 (log; only fires for tool-using or background subagents)
 ├── Task completed                (log; level depends on status)
@@ -164,11 +166,9 @@ Three system-message events emitted during the subagent run surface as logs unde
 
 ### Parallel subagents
 
-Multiple Task dispatches in a single parent turn produce multiple concurrent `subagent` spans, each keyed by its own `agent_id`. The integration's per-conversation `subagent_spans` dict disambiguates by `agent_id`, so each subagent's tool calls correctly nest under its own span even when their hook callbacks interleave over the SDK's control channel.
+Multiple Task dispatches in a single parent turn produce multiple concurrent `subagent` spans, each keyed by its own `agent_id`. The integration's per-conversation `subagent_spans` dict disambiguates by `agent_id`, so each subagent's tool calls correctly nest under its own span even when their hook callbacks interleave over the SDK's control channel. Chat spans emitted by parallel subagents disambiguate the same way: each subagent-originating `UserMessage` carries a unique `parent_tool_use_id` that resolves through the `parent_tool_use_id_to_agent_id` map (populated by `TaskStartedMessage`) to the right subagent span.
 
-### Known limitation: subagent chat spans flatten under invoke_agent
-
-Subagent assistant turns produce `chat` spans flat under `invoke_agent` rather than nested under their parent `subagent` span. The dispatch loop's `handle_assistant_message` / `handle_user_message` don't have `agent_id` available — only `parent_tool_use_id`. Cross-correlation is still possible via the `claude.parent_tool_use_id` attribute already captured on each chat span, joined to the parent's `execute_tool Agent` span via `gen_ai.tool.call.id`. Fully nesting subagent chat spans under the subagent span requires building a `parent_tool_use_id → agent_id` map and refactoring `_ConversationState`'s span lifecycle; tracked separately to land with dedicated design + review attention.
+Re-parented chat spans also carry `claude.in_subagent.agent_id` and `claude.in_subagent.agent_type` for queryability — useful in renderers that flatten the trace tree, and for SQL filters like `WHERE attributes->>'claude.in_subagent.agent_type' = 'reviewer'`.
 
 ## End-of-conversation result fields
 

--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -61,6 +61,8 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_ENABLE_FILE_CHECKPOINTING,
     CLAUDE_FORK_ON_RESUME,
     CLAUDE_INCLUDE_PARTIAL_MESSAGES,
+    CLAUDE_IN_SUBAGENT_AGENT_ID,
+    CLAUDE_IN_SUBAGENT_AGENT_TYPE,
     CLAUDE_MAX_BUDGET_USD,
     CLAUDE_MAX_TURNS,
     CLAUDE_MCP_ENABLED,
@@ -812,7 +814,7 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                         if isinstance(msg, AssistantMessage):
                             state.handle_assistant_message(msg)
                         elif isinstance(msg, UserMessage):
-                            state.handle_user_message()
+                            state.handle_user_message(msg)
                         elif isinstance(msg, ResultMessage):
                             _record_result(root_span, msg)
                             if state.model:  # pragma: no branch
@@ -1133,6 +1135,16 @@ class _ConversationState:
         # treatment.
         self.subagent_spans: dict[str, LogfireSpan] = {}
         self.subagent_count = 0
+        # Issue #26: parent ``Task`` tool_use_id → subagent ``agent_id`` map,
+        # populated when ``TaskStartedMessage`` arrives (carries both fields).
+        # Used by ``open_chat_span`` to re-parent chat spans emitted during
+        # a subagent's turn under the matching ``subagent {agent_type}``
+        # span. Relies on the empirical equality
+        # ``TaskStartedMessage.task_id == SubagentStart.agent_id`` — verified
+        # under sequential and interleaved-parallel dispatches in the
+        # recon harness; degrades safely (chat span parents to root) if it
+        # ever breaks. Cleaned up at ``SubagentStop`` to bound size.
+        self.parent_tool_use_id_to_agent_id: dict[str, str] = {}
 
     def add_tool_result(self, tool_use_id: str, tool_name: str, result: Any) -> None:
         """Record a tool result to include in the next chat span's input messages."""
@@ -1142,8 +1154,17 @@ class _ConversationState:
         )
         self._history.append(msg)
 
-    def open_chat_span(self) -> None:
-        """Open a new chat span — call when the LLM starts processing."""
+    def open_chat_span(self, parent_tool_use_id: str | None = None) -> None:
+        """Open a new chat span — call when the LLM starts processing.
+
+        Issue #26: when ``parent_tool_use_id`` matches a known subagent via
+        ``parent_tool_use_id_to_agent_id``, parent the chat span under that
+        subagent's open envelope span instead of the root ``invoke_agent``.
+        Falls back to root parenting on any miss (unknown ``parent_tool_use_id``,
+        subagent already stopped, agent_id binding not yet populated) — the
+        chat span attaches under the active OTel context, which is the root
+        when no override is in play.
+        """
         self.close_chat_span()
 
         span_data: dict[str, Any] = {
@@ -1156,11 +1177,49 @@ class _ConversationState:
         if self._system_instructions:  # pragma: no branch
             span_data[SYSTEM_INSTRUCTIONS] = self._system_instructions
 
-        self._current_span = self.logfire.span('chat', **span_data)
-        # Start without entering context — chat spans don't need to be on the
-        # context stack, and this allows close_chat_span() to be called safely
-        # from hooks running in different async contexts.
-        self._current_span._start()  # pyright: ignore[reportPrivateUsage]
+        # Re-parent under the subagent OTel context if available; otherwise
+        # the chat span attaches under the active context (root invoke_agent).
+        # Span parent is fixed at creation, so we attach + create + detach
+        # immediately — chat spans never enter the context stack themselves.
+        token: Any = None
+        if parent_tool_use_id is not None:
+            agent_id = self.parent_tool_use_id_to_agent_id.get(parent_tool_use_id)
+            subagent_span = self.subagent_spans.get(agent_id) if agent_id is not None else None
+            if subagent_span is not None:
+                # Annotate the chat span with subagent attribution so it
+                # remains queryable even if visual nesting can't be
+                # resolved by a downstream renderer.
+                span_data[CLAUDE_IN_SUBAGENT_AGENT_ID] = agent_id
+                agent_type = (subagent_span.attributes or {}).get(CLAUDE_AGENT_TYPE)
+                if agent_type:
+                    span_data[CLAUDE_IN_SUBAGENT_AGENT_TYPE] = agent_type
+                otel_span = subagent_span._span  # pyright: ignore[reportPrivateUsage]
+                if otel_span is not None:
+                    token = context_api.attach(trace_api.set_span_in_context(otel_span))
+            else:
+                # Designed degradation: ptui present but binding lookup
+                # missed. Either the SDK delivered a chat message before its
+                # owning ``TaskStartedMessage`` (would invalidate the
+                # ordering invariant the recon harness verified), or
+                # ``task_id == agent_id`` no longer holds, or the subagent
+                # already stopped (stale ptui — see ``_record_subagent_stop``
+                # cleanup). Surface as debug so SDK drift becomes
+                # observable in instrumented sessions without spamming
+                # routine traces.
+                self.logfire.debug(
+                    'subagent chat-span re-parent skipped: ptui={parent_tool_use_id} not bound',
+                    parent_tool_use_id=parent_tool_use_id,
+                    agent_id_lookup_hit=agent_id is not None,
+                )
+        try:
+            self._current_span = self.logfire.span('chat', **span_data)
+            # Start without entering context — chat spans don't need to be on
+            # the context stack, and this allows close_chat_span() to be
+            # called safely from hooks running in different async contexts.
+            self._current_span._start()  # pyright: ignore[reportPrivateUsage]
+        finally:
+            if token is not None:
+                context_api.detach(token)
         self._current_output_parts = []
 
     def close_chat_span(self) -> None:
@@ -1176,9 +1235,19 @@ class _ConversationState:
             self._current_span = None
             self._current_output_parts = []
 
-    def handle_user_message(self) -> None:
-        """Handle UserMessage: open a new chat span for the next LLM call."""
-        self.open_chat_span()
+    def handle_user_message(self, message: UserMessage | None = None) -> None:
+        """Open a new chat span on UserMessage, re-parenting it under the
+        matching subagent envelope when the message originates inside one
+        (issue #26).
+
+        ``UserMessage.parent_tool_use_id`` is set when the SDK forwards a
+        subagent's turn through the parent stream. ``open_chat_span``
+        consults ``parent_tool_use_id_to_agent_id`` (populated by
+        ``_record_task_started``) to find the matching subagent span and
+        attach the new chat span under it.
+        """
+        # ``getattr(None, ...)`` returns the default safely, so no extra None guard.
+        self.open_chat_span(parent_tool_use_id=getattr(message, 'parent_tool_use_id', None))
 
     def handle_assistant_message(self, message: AssistantMessage) -> None:
         """Handle AssistantMessage: add output and usage to the current chat span."""
@@ -1277,6 +1346,12 @@ class _ConversationState:
         for span in self.active_tool_spans.values():
             span._end()  # pyright: ignore[reportPrivateUsage]
         self.active_tool_spans.clear()
+        # Issue #26: drop any ptui→agent_id entries that survived (session
+        # abort with subagents still mid-flight). Symmetric with the
+        # surrounding clear()s — the state object is dropped at
+        # ``_clear_state`` so this is mostly cosmetic, but matches the
+        # established drain pattern.
+        self.parent_tool_use_id_to_agent_id.clear()
 
 
 def _record_rate_limit_event(
@@ -1806,6 +1881,15 @@ def _record_subagent_stop(state: _ConversationState, input_data: Any) -> None:
         return
 
     span = state.subagent_spans.pop(agent_id, None)
+    # Issue #26: drop ptui→agent_id entries for this subagent so the map
+    # doesn't grow across long sessions. Late chat messages bearing this
+    # ptui (rare — would imply SDK out-of-order delivery) degrade safely:
+    # the lookup misses and the chat span parents under root.
+    state.parent_tool_use_id_to_agent_id = {
+        ptui: aid
+        for ptui, aid in state.parent_tool_use_id_to_agent_id.items()
+        if aid != agent_id
+    }
     last_assistant_message = input_data.get('last_assistant_message')
     transcript_path = input_data.get('agent_transcript_path')
 
@@ -1823,6 +1907,12 @@ def _record_task_started(state: _ConversationState, msg: Any) -> None:
     Carries the parent's ``tool_use_id`` (the Task tool call's id) so
     downstream queries can join Task lifecycle events to the parent's
     ``execute_tool`` span via ``gen_ai.tool.call.id``.
+
+    Issue #26: also populates ``parent_tool_use_id_to_agent_id`` so chat
+    spans emitted during the subagent's turn can be re-parented under the
+    matching ``subagent {agent_type}`` envelope. Relies on the empirical
+    ``task_id == agent_id`` equality (verified in recon for sequential and
+    interleaved-parallel dispatches).
     """
     attrs = _msg_attrs(msg, (
         ('task_id', CLAUDE_TASK_ID),
@@ -1830,6 +1920,10 @@ def _record_task_started(state: _ConversationState, msg: Any) -> None:
         ('task_type', CLAUDE_TASK_TYPE),
         ('tool_use_id', TOOL_CALL_ID),
     ))
+    tool_use_id = getattr(msg, 'tool_use_id', None)
+    task_id = getattr(msg, 'task_id', None)
+    if tool_use_id and task_id:
+        state.parent_tool_use_id_to_agent_id[tool_use_id] = task_id
     state.logfire.info('Task started', **attrs)
 
 

--- a/logfire/_internal/integrations/llm_providers/semconv.py
+++ b/logfire/_internal/integrations/llm_providers/semconv.py
@@ -297,6 +297,14 @@ CLAUDE_SUBAGENT_LAST_ASSISTANT_MESSAGE = 'claude.subagent.last_assistant_message
 # Cumulative subagent count emitted on the root invoke_agent at close.
 CLAUDE_SUBAGENT_COUNT = 'claude.subagent_count'
 
+# Issue #26: stamped on per-turn ``chat`` spans whose ``UserMessage.parent_tool_use_id``
+# resolves to a known subagent. The chat span is also re-parented under the
+# matching ``subagent {agent_type}`` envelope; these attrs make the
+# attribution queryable independent of trace-tree rendering and are kept
+# verbatim across renderers that flatten the hierarchy.
+CLAUDE_IN_SUBAGENT_AGENT_ID = 'claude.in_subagent.agent_id'
+CLAUDE_IN_SUBAGENT_AGENT_TYPE = 'claude.in_subagent.agent_type'
+
 # ``AgentDefinition`` metadata captured on the subagent span at
 # ``SubagentStart`` time (issue #3, Option B). Mirrors the
 # ``_options_attrs`` pattern from #8 — looked up via

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -40,6 +40,7 @@ from claude_agent_sdk import (
     ThinkingBlock,
     ToolResultBlock,
     ToolUseBlock,
+    UserMessage,
 )
 from claude_agent_sdk._errors import CLINotFoundError, ProcessError
 from claude_agent_sdk.types import HookContext
@@ -2396,6 +2397,220 @@ async def test_three_parallel_subagents_each_tool_lands_under_correct_span(expor
     assert parent_by_tool_id['tu_A1'] == by_agent_id['A_id']['context']['span_id']
     assert parent_by_tool_id['tu_B1'] == by_agent_id['B_id']['context']['span_id']
     assert parent_by_tool_id['tu_C1'] == by_agent_id['C_id']['context']['span_id']
+
+
+# ---------------------------------------------------------------------------
+# Issue #26: chat-span re-parenting under subagent envelope.
+#
+# These tests use the SimpleNamespace-style direct-call pattern (matching
+# the surrounding #3 tests) rather than a cassette: the binding logic is
+# pure span-construction and the cassette would only re-prove what the
+# unit tests already lock.
+# ---------------------------------------------------------------------------
+
+
+def _task_started_msg(task_id: str, tool_use_id: str) -> Any:
+    """Build a TaskStartedMessage-shaped object for ``_record_task_started``.
+
+    ``_record_task_started`` and its helpers use ``getattr(msg, ..., None)``,
+    so only the fields the binding logic actually reads need to be set.
+    """
+    return SimpleNamespace(task_id=task_id, tool_use_id=tool_use_id)
+
+
+@pytest.mark.anyio
+async def test_subagent_chat_spans_nest_under_subagent_envelope(exporter: TestExporter) -> None:
+    """**The #26 lock.** A chat span opened via ``handle_user_message`` with
+    a ``UserMessage.parent_tool_use_id`` matching a known subagent parents
+    under that subagent's span — not the root ``invoke_agent`` — and carries
+    the ``claude.in_subagent.*`` annotation attributes for queryability.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            # SubagentStart populates state.subagent_spans[agent_id].
+            _record_subagent_start(state, {'agent_id': 'agent_X', 'agent_type': 'echo-helper'})
+            # TaskStartedMessage populates the parent_tool_use_id → agent_id map.
+            _record_task_started(state, _task_started_msg(task_id='agent_X', tool_use_id='tu_parent_1'))
+
+            # Subagent's UserMessage arrives with parent_tool_use_id set.
+            msg = UserMessage(content='echo this', parent_tool_use_id='tu_parent_1')
+            state.handle_user_message(msg)
+
+            # Close out so spans are exported.
+            state.close_chat_span()
+            _record_subagent_stop(state, {'agent_id': 'agent_X', 'agent_type': 'echo-helper'})
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    sub_span = next(s for s in spans if s['name'] == 'subagent {agent_type}')
+    chat_span = next(s for s in spans if s['name'] == 'chat')
+    assert chat_span['parent']['span_id'] == sub_span['context']['span_id']
+    assert chat_span['attributes']['claude.in_subagent.agent_id'] == 'agent_X'
+    assert chat_span['attributes']['claude.in_subagent.agent_type'] == 'echo-helper'
+
+
+@pytest.mark.anyio
+async def test_three_parallel_subagents_chat_spans_attribute_correctly(exporter: TestExporter) -> None:
+    """Parallel-subagent disambiguation for chat spans. Three subagents
+    with overlapping lifetimes; each subagent emits its own chat turns
+    interleaved with the others'. Every chat span must land under its
+    own subagent — not a sibling subagent's, not the root.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            # Three subagents start; bindings populated in arbitrary order.
+            _record_subagent_start(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
+            _record_subagent_start(state, {'agent_id': 'B_id', 'agent_type': 'planner'})
+            _record_subagent_start(state, {'agent_id': 'C_id', 'agent_type': 'reviewer'})  # same type as A
+            _record_task_started(state, _task_started_msg(task_id='A_id', tool_use_id='tu_A'))
+            _record_task_started(state, _task_started_msg(task_id='B_id', tool_use_id='tu_B'))
+            _record_task_started(state, _task_started_msg(task_id='C_id', tool_use_id='tu_C'))
+
+            # Interleaved chat opens — each handle_user_message closes the
+            # previous chat span (single _current_span) so every open
+            # produces a fresh chat span we can inspect.
+            state.handle_user_message(UserMessage(content='c1', parent_tool_use_id='tu_A'))
+            state.handle_user_message(UserMessage(content='c2', parent_tool_use_id='tu_C'))
+            state.handle_user_message(UserMessage(content='c3', parent_tool_use_id='tu_B'))
+            state.handle_user_message(UserMessage(content='c4', parent_tool_use_id='tu_A'))
+            state.handle_user_message(UserMessage(content='c5', parent_tool_use_id='tu_C'))
+            state.close_chat_span()
+
+            _record_subagent_stop(state, {'agent_id': 'B_id', 'agent_type': 'planner'})
+            _record_subagent_stop(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
+            _record_subagent_stop(state, {'agent_id': 'C_id', 'agent_type': 'reviewer'})
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    sub_spans = [s for s in spans if s['name'] == 'subagent {agent_type}']
+    assert len(sub_spans) == 3
+    by_agent_id = {s['attributes']['claude.agent_id']: s for s in sub_spans}
+
+    chat_spans = [s for s in spans if s['name'] == 'chat']
+    assert len(chat_spans) == 5
+    # Each chat span's parent must be the subagent matching its
+    # claude.in_subagent.agent_id annotation — not a sibling, not the root.
+    for c in chat_spans:
+        annotated_agent_id = c['attributes']['claude.in_subagent.agent_id']
+        assert c['parent']['span_id'] == by_agent_id[annotated_agent_id]['context']['span_id'], (
+            f'chat span annotated with agent_id={annotated_agent_id} parented under '
+            f"span_id={c['parent']['span_id']}, expected {by_agent_id[annotated_agent_id]['context']['span_id']}"
+        )
+
+
+@pytest.mark.anyio
+async def test_chat_spans_with_no_active_subagent_attach_to_invoke_agent(exporter: TestExporter) -> None:
+    """Regression guard: a UserMessage with no ``parent_tool_use_id`` (the
+    common, non-subagent path) keeps parenting chat spans under the root
+    ``invoke_agent`` — the #26 patch must not redirect non-subagent traffic.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            state.handle_user_message(UserMessage(content='hi'))
+            state.close_chat_span()
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat_span = next(s for s in spans if s['name'] == 'chat')
+    root_span = next(s for s in spans if s['name'] == 'invoke_agent')
+    assert chat_span['parent']['span_id'] == root_span['context']['span_id']
+    assert 'claude.in_subagent.agent_id' not in chat_span['attributes']
+
+
+@pytest.mark.anyio
+async def test_chat_span_with_unknown_parent_tool_use_id_falls_back_to_root(exporter: TestExporter) -> None:
+    """Defensive degradation: if a UserMessage carries a ``parent_tool_use_id``
+    that has no entry in ``parent_tool_use_id_to_agent_id`` (TaskStartedMessage
+    didn't arrive yet, or the SDK skipped it), the chat span attaches under
+    the root ``invoke_agent`` instead of crashing. No annotation attrs are
+    stamped since attribution is unknown.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            state.handle_user_message(UserMessage(content='hi', parent_tool_use_id='tu_unknown'))
+            state.close_chat_span()
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat_span = next(s for s in spans if s['name'] == 'chat')
+    root_span = next(s for s in spans if s['name'] == 'invoke_agent')
+    assert chat_span['parent']['span_id'] == root_span['context']['span_id']
+    assert 'claude.in_subagent.agent_id' not in chat_span['attributes']
+
+
+@pytest.mark.anyio
+async def test_chat_span_with_stale_parent_tool_use_id_after_stop_falls_back_to_root(exporter: TestExporter) -> None:
+    """Distinct from the *unknown-ptui* path: this exercises the
+    *cleanup-then-degrade* contract where a binding existed, was dropped
+    at ``_record_subagent_stop``, and a late chat message arrives bearing
+    the now-stale ``parent_tool_use_id``. Designed degradation per the
+    integration's docstring: chat span attaches under root, no annotation.
+    Locks the cleanup side-effect that the patch comments call out as
+    load-bearing.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _set_state(state)
+        try:
+            _record_subagent_start(state, {'agent_id': 'agent_X', 'agent_type': 'echo-helper'})
+            _record_task_started(state, _task_started_msg(task_id='agent_X', tool_use_id='tu_stale'))
+            _record_subagent_stop(state, {'agent_id': 'agent_X', 'agent_type': 'echo-helper'})
+            # Subagent already stopped — late chat message arrives with
+            # the now-stale ptui (rare; would imply SDK out-of-order
+            # delivery).
+            state.handle_user_message(UserMessage(content='late', parent_tool_use_id='tu_stale'))
+            state.close_chat_span()
+        finally:
+            _clear_state()
+
+    spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
+    chat_span = next(s for s in spans if s['name'] == 'chat')
+    root_span = next(s for s in spans if s['name'] == 'invoke_agent')
+    assert chat_span['parent']['span_id'] == root_span['context']['span_id']
+    assert 'claude.in_subagent.agent_id' not in chat_span['attributes']
+
+
+def test_subagent_stop_clears_parent_tool_use_id_to_agent_id_entries() -> None:
+    """``_record_subagent_stop`` drops every ``ptui → agent_id`` entry for
+    the closing subagent so the map doesn't grow unboundedly across long
+    sessions. Entries for OTHER live subagents must be preserved.
+    """
+    logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
+    with logfire_instance.span('invoke_agent') as root:
+        state = _ConversationState(logfire=logfire_instance, root_span=root, input_messages=[])
+        _record_subagent_start(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
+        _record_subagent_start(state, {'agent_id': 'B_id', 'agent_type': 'reviewer'})
+        _record_task_started(state, _task_started_msg(task_id='A_id', tool_use_id='tu_A1'))
+        _record_task_started(state, _task_started_msg(task_id='A_id', tool_use_id='tu_A2'))
+        _record_task_started(state, _task_started_msg(task_id='B_id', tool_use_id='tu_B1'))
+
+        assert state.parent_tool_use_id_to_agent_id == {
+            'tu_A1': 'A_id', 'tu_A2': 'A_id', 'tu_B1': 'B_id',
+        }
+
+        _record_subagent_stop(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
+        # Both A entries dropped; B preserved.
+        assert state.parent_tool_use_id_to_agent_id == {'tu_B1': 'B_id'}
+
+        _record_subagent_stop(state, {'agent_id': 'B_id', 'agent_type': 'reviewer'})
+        assert state.parent_tool_use_id_to_agent_id == {}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## Summary

Closes the second half of the subagent observability gap left after #3. Per-turn `chat` spans emitted while a subagent runs now nest under the matching `subagent {agent_type}` envelope instead of sitting flat under `invoke_agent` as siblings.

Visual confirmation in the logfire UI: each subagent now shows its own `chat → execute_tool → chat` sequence as children of its envelope span, which matches how the same trace looks for the parent thread.

Closes #26.

## How

`AssistantMessage` / `UserMessage` carry `parent_tool_use_id` when the SDK forwards a subagent's turn through the parent stream. `TaskStartedMessage` carries `(task_id, tool_use_id)`. Empirically `task_id == agent_id` and `TaskStartedMessage.tool_use_id == subagent's parent_tool_use_id`, giving a collision-free `parent_tool_use_id → agent_id` binding.

- New `_ConversationState.parent_tool_use_id_to_agent_id` dict, populated in `_record_task_started`, drained in `_record_subagent_stop` and `state.close()`.
- `handle_user_message` accepts the `UserMessage` and threads `parent_tool_use_id` into `open_chat_span`.
- `open_chat_span` looks up the matching subagent span and attaches the OTel context to it before creating the chat span (parent is fixed at creation, attach window is short, chat spans still don't enter the context stack).
- Re-parented chat spans also carry `claude.in_subagent.agent_id` / `claude.in_subagent.agent_type` for renderers that flatten the tree and for SQL queryability.

## Recon (locked before patching)

Two empirical harnesses verified the binding before committing to a state-machine refactor:

| Check | Single subagent | 3-batch interleaved |
|---|---|---|
| `task_id == agent_id` | ✅ | ✅ all 3 |
| `TaskStartedMessage.tool_use_id == ptui on subagent msgs` | ✅ | ✅ all 3 |
| TaskStartedMessage arrives before first subagent message | +0.5ms | +0.18 / +0.26 / +1.07ms |

Both `task_id == agent_id` and the TaskStartedMessage-before-first-subagent-message ordering are empirical, not contractual. Binding misses (unknown ptui, subagent already stopped, future SDK drift) emit a debug log and degrade safely to root parenting — no crash, no misattribution. The debug log makes drift observable in instrumented sessions.

## What's unchanged on purpose

- **Counter scoping**: subagent activity still counts toward parent `invoke_agent` aggregates (token usage, num_turns, `claude.tools_used`, etc.). No per-subagent counter split.
- **`pydantic_ai.all_messages` on root**: `_history` accumulates all turns regardless of where their chat spans land, so the Model Run rendering on the root span keeps the full conversation view.
- **Test pattern**: new tests use direct `_ConversationState` calls matching the #3 subagent tests' pattern; not adding a cassette-driven end-to-end test (would re-prove the same binding logic the unit tests already lock).

## Adversarial review

3 reviewers in parallel (Opus P0/P1, Sonnet pattern compliance, code-simplifier). No P0 findings. Acted on:

- `state.close()` now clears `parent_tool_use_id_to_agent_id` for symmetry with sibling drains.
- Tightened `handle_user_message` signature to `UserMessage | None`.
- Updated docstring summary to reflect re-parenting behavior.
- Added debug log at binding-miss site for SDK-drift observability.
- Added stale-ptui-after-Stop test locking the cleanup-then-degrade contract.

Skipped (with rationale):
- Sonnet "use semconv constants in tests": existing tests use raw attribute strings; staying consistent.
- Opus "hooks-vs-iterator e2e race test": existing #3 tests use the same direct-call pattern; production race is locked at the protocol level by the SDK's hook-await control flow.
- code-simplifier rejected `.pop()` in a loop over the dict-comprehension cleanup — the comprehension is the canonical filter idiom.

## Test plan

- [x] `tests/otel_integrations/test_claude_agent_sdk.py`: 98/98 pass (deselecting the pre-existing `test_tool_use_conversation_cassette` flake).
- [x] Empirical baseline (`empirical/issue_26_baseline.py`): chat spans during subagent are misparented under root.
- [x] Empirical post-patch (`empirical/issue_26_verify.py`): all chat-during-subagent spans correctly under subagent envelope, annotation attrs present.
- [x] Empirical parallel: 3 subagents, 2 chat spans each, every chat span attributed to its own subagent (no cross-talk).
- [x] Live logfire UI: visual confirmation of nesting on a real trace.