### PR TITLE
Clean up typecheck / lint / format debt for upstream contribution

### DIFF
--- a/logfire/_internal/integrations/claude_agent_sdk.py
+++ b/logfire/_internal/integrations/claude_agent_sdk.py
@@ -21,17 +21,6 @@ from claude_agent_sdk import (
     UserMessage,
 )
 from claude_agent_sdk.types import HookContext, SyncHookJSONOutput
-
-# Optional message types — resolved at module load from the installed SDK so
-# older versions that lack them still import cleanly. Using getattr avoids
-# a redundant try/except on a module we've already imported above.
-RateLimitEvent = getattr(claude_agent_sdk, 'RateLimitEvent', None)
-MirrorErrorMessage = getattr(claude_agent_sdk, 'MirrorErrorMessage', None)
-# Issue #3 — Task* SystemMessage subclasses for subagent dispatch.
-TaskStartedMessage = getattr(claude_agent_sdk, 'TaskStartedMessage', None)
-TaskProgressMessage = getattr(claude_agent_sdk, 'TaskProgressMessage', None)
-TaskNotificationMessage = getattr(claude_agent_sdk, 'TaskNotificationMessage', None)
-
 from opentelemetry import context as context_api, trace as trace_api
 
 from logfire._internal.integrations.llm_providers.semconv import (
@@ -60,9 +49,9 @@ from logfire._internal.integrations.llm_providers.semconv import (
     CLAUDE_EFFORT,
     CLAUDE_ENABLE_FILE_CHECKPOINTING,
     CLAUDE_FORK_ON_RESUME,
-    CLAUDE_INCLUDE_PARTIAL_MESSAGES,
     CLAUDE_IN_SUBAGENT_AGENT_ID,
     CLAUDE_IN_SUBAGENT_AGENT_TYPE,
+    CLAUDE_INCLUDE_PARTIAL_MESSAGES,
     CLAUDE_MAX_BUDGET_USD,
     CLAUDE_MAX_TURNS,
     CLAUDE_MCP_ENABLED,
@@ -148,11 +137,20 @@ from logfire._internal.integrations.llm_providers.semconv import (
 )
 from logfire._internal.utils import handle_internal_errors
 
+# Optional message types — resolved at module load from the installed SDK so
+# older versions that lack them still import cleanly. Using getattr avoids
+# a redundant try/except on a module we've already imported above.
+RateLimitEvent = getattr(claude_agent_sdk, 'RateLimitEvent', None)
+MirrorErrorMessage = getattr(claude_agent_sdk, 'MirrorErrorMessage', None)
+# Issue #3 — Task* SystemMessage subclasses for subagent dispatch.
+TaskStartedMessage = getattr(claude_agent_sdk, 'TaskStartedMessage', None)
+TaskProgressMessage = getattr(claude_agent_sdk, 'TaskProgressMessage', None)
+TaskNotificationMessage = getattr(claude_agent_sdk, 'TaskNotificationMessage', None)
+
 if TYPE_CHECKING:
     # String forward refs for the SDK types that may be absent at runtime on
     # older SDK versions (see getattr above).
-    from claude_agent_sdk import MirrorErrorMessage as _MirrorErrorMessage
-    from claude_agent_sdk import RateLimitEvent as _RateLimitEvent
+    from claude_agent_sdk import MirrorErrorMessage as _MirrorErrorMessage, RateLimitEvent as _RateLimitEvent
 
     from logfire._internal.main import Logfire, LogfireSpan
 
@@ -353,7 +351,7 @@ def _options_attrs(options: Any) -> dict[str, Any]:
     # reprs into the attribute.
     agents = getattr(options, 'agents', None)
     if isinstance(agents, dict) and agents:
-        attrs[CLAUDE_AGENTS] = sorted(agents.keys())
+        attrs[CLAUDE_AGENTS] = sorted(cast('dict[str, Any]', agents).keys())
 
     return attrs
 
@@ -363,7 +361,7 @@ def _options_attrs(options: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _tool_parent_otel_span(state: _ConversationState, input_data: Any) -> Any:
+def _tool_parent_otel_span(state: _ConversationState, input_data: dict[str, Any]) -> Any:
     """Return the OTel span the ``execute_tool`` should parent under (issue #3).
 
     When the tool-lifecycle hook fires inside a subagent context (``agent_id``
@@ -374,12 +372,11 @@ def _tool_parent_otel_span(state: _ConversationState, input_data: Any) -> Any:
     Returns ``None`` if no usable parent OTel span is available (root span
     already ended); caller should noop.
     """
-    if isinstance(input_data, dict):
-        agent_id = input_data.get('agent_id')
-        if agent_id and (subagent_span := state.subagent_spans.get(agent_id)):
-            otel = subagent_span._span  # pyright: ignore[reportPrivateUsage]
-            if otel is not None:
-                return otel
+    agent_id = input_data.get('agent_id')
+    if agent_id and (subagent_span := state.subagent_spans.get(agent_id)):
+        otel = subagent_span._span  # pyright: ignore[reportPrivateUsage]
+        if otel is not None:
+            return otel
     return state.root_span._span  # pyright: ignore[reportPrivateUsage]
 
 
@@ -439,7 +436,7 @@ async def pre_tool_use_hook(
             # nested-dict mutations would silently miss the diff — revisit
             # with ``copy.deepcopy`` then.
             if isinstance(tool_input, dict):
-                state.original_tool_inputs[tool_use_id] = dict(tool_input)
+                state.original_tool_inputs[tool_use_id] = dict(cast('dict[str, Any]', tool_input))
         finally:
             context_api.detach(token)
 
@@ -474,11 +471,7 @@ async def post_tool_use_hook(
         # canonical attribute with the executed value and surface the
         # original under ``claude.tool_call.arguments.original``.
         executed_input = input_data.get('tool_input')
-        if (
-            isinstance(executed_input, dict)
-            and isinstance(original_input, dict)
-            and executed_input != original_input
-        ):
+        if isinstance(executed_input, dict) and isinstance(original_input, dict) and executed_input != original_input:
             span.set_attribute(TOOL_CALL_ARGUMENTS, executed_input)
             span.set_attribute(CLAUDE_TOOL_CALL_ARGUMENTS_ORIGINAL, original_input)
 
@@ -862,8 +855,6 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
                 yield msg
 
         cls.receive_messages = patched_receive_messages
-    else:  # pragma: no cover
-        patched_receive_messages = None
 
     # --- Patch connect / disconnect (issue #11) ---
     # Lifecycle spans capture CLI-startup latency (a real tail-latency
@@ -927,7 +918,9 @@ def instrument_claude_agent_sdk(logfire_instance: Logfire) -> AbstractContextMan
     if original_toggle_mcp_server is not None:
 
         @functools.wraps(original_toggle_mcp_server)
-        async def patched_toggle_mcp_server(self: Any, server_name: str, enabled: bool, *args: Any, **kwargs: Any) -> Any:
+        async def patched_toggle_mcp_server(
+            self: Any, server_name: str, enabled: bool, *args: Any, **kwargs: Any
+        ) -> Any:
             with _traced_span(
                 logfire_claude,
                 'mcp.toggle',
@@ -1036,11 +1029,11 @@ def _make_control_patch(
 
 
 def _inject_tracing_hooks(options: Any) -> None:
-    """Inject logfire tracing hooks into ClaudeAgentOptions and wrap any
-    ``can_use_tool`` callback for outcome tracing (issue #10).
+    """Inject logfire tracing hooks into ClaudeAgentOptions.
 
-    Guards against duplicate injection / double-wrap when the same options
-    object is reused across multiple ClaudeSDKClient instances.
+    Also wraps any ``can_use_tool`` callback for outcome tracing (issue
+    #10). Guards against duplicate injection / double-wrap when the same
+    options object is reused across multiple ClaudeSDKClient instances.
     """
     if not hasattr(options, 'hooks'):
         return
@@ -1236,9 +1229,10 @@ class _ConversationState:
             self._current_output_parts = []
 
     def handle_user_message(self, message: UserMessage | None = None) -> None:
-        """Open a new chat span on UserMessage, re-parenting it under the
-        matching subagent envelope when the message originates inside one
-        (issue #26).
+        """Open a new chat span on UserMessage.
+
+        Re-parents under the matching subagent envelope when the message
+        originates inside one (issue #26).
 
         ``UserMessage.parent_tool_use_id`` is set when the SDK forwards a
         subagent's turn through the parent stream. ``open_chat_span``
@@ -1354,9 +1348,7 @@ class _ConversationState:
         self.parent_tool_use_id_to_agent_id.clear()
 
 
-def _record_rate_limit_event(
-    logfire_instance: Logfire, root_span: LogfireSpan, msg: _RateLimitEvent
-) -> None:
+def _record_rate_limit_event(logfire_instance: Logfire, root_span: LogfireSpan, msg: _RateLimitEvent) -> None:
     """Record a RateLimitEvent as a level-appropriate log under the root span.
 
     The SDK emits these whenever the CLI reports a rate-limit state transition
@@ -1409,6 +1401,7 @@ def _record_mirror_error(logfire_instance: Logfire, msg: _MirrorErrorMessage) ->
     attrs: dict[str, Any] = {ERROR_TYPE: 'MirrorError'}
     key = getattr(msg, 'key', None)
     if isinstance(key, dict):
+        key = cast('dict[str, Any]', key)
         if (sid := key.get('session_id')) is not None:
             attrs[CONVERSATION_ID] = sid
         if (pk := key.get('project_key')) is not None:
@@ -1481,16 +1474,17 @@ def _record_result(span: LogfireSpan, msg: ResultMessage) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _hook_session_id(input_data: Any) -> dict[str, Any]:
-    """Pull ``session_id`` from a hook input dict, mapped to the OTel semconv
-    ``gen_ai.conversation.id``. Returns ``{}`` when absent so callers can
-    splat it into a log call unconditionally.
+def _hook_session_id(input_data: dict[str, Any]) -> dict[str, Any]:
+    """Pull ``session_id`` from a hook input dict.
+
+    Mapped to the OTel semconv ``gen_ai.conversation.id``. Returns ``{}``
+    when absent so callers can splat it into a log call unconditionally.
     """
-    sid = (input_data or {}).get('session_id') if isinstance(input_data, dict) else None
+    sid = input_data.get('session_id')
     return {CONVERSATION_ID: sid} if sid else {}
 
 
-def _record_user_prompt_submit(state: _ConversationState, input_data: Any) -> None:
+def _record_user_prompt_submit(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Record a UserPromptSubmit hook event as an info log under the root span.
 
     ``claude.user_prompt`` is intentionally NOT on the scrubber's SAFE_KEYS:
@@ -1499,8 +1493,6 @@ def _record_user_prompt_submit(state: _ConversationState, input_data: Any) -> No
     can use a ``scrubbing_callback``.
     """
     state.user_prompt_count += 1
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     prompt = input_data.get('prompt')
     attrs: dict[str, Any] = {**_hook_session_id(input_data)}
     if prompt is not None:
@@ -1508,7 +1500,7 @@ def _record_user_prompt_submit(state: _ConversationState, input_data: Any) -> No
     state.logfire.info('Hook: UserPromptSubmit', **attrs)
 
 
-def _record_stop(state: _ConversationState, input_data: Any) -> None:
+def _record_stop(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Record a Stop hook event as an info log under the root span.
 
     Captures ``last_assistant_message`` defensively via ``.get()`` —
@@ -1517,8 +1509,6 @@ def _record_stop(state: _ConversationState, input_data: Any) -> None:
     skip the attribute. Goes through the scrubber's SAFE_KEYS allowlist
     because it's model-generated text (mirrors ``claude.result.text``).
     """
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     attrs: dict[str, Any] = {**_hook_session_id(input_data)}
     # Emit ``stop_hook_active`` only when True — almost always False.
     if input_data.get('stop_hook_active'):
@@ -1529,7 +1519,7 @@ def _record_stop(state: _ConversationState, input_data: Any) -> None:
     state.logfire.info('Hook: Stop', **attrs)
 
 
-def _record_pre_compact(state: _ConversationState, input_data: Any) -> None:
+def _record_pre_compact(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Record a PreCompact hook event as a warn log under the root span.
 
     Compaction is the strongest leading indicator that the session is
@@ -1537,8 +1527,6 @@ def _record_pre_compact(state: _ConversationState, input_data: Any) -> None:
     without being treated as a hard error.
     """
     state.compact_count += 1
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     attrs: dict[str, Any] = {**_hook_session_id(input_data)}
     if (trigger := input_data.get('trigger')) is not None:
         attrs[CLAUDE_COMPACT_TRIGGER] = trigger
@@ -1547,7 +1535,7 @@ def _record_pre_compact(state: _ConversationState, input_data: Any) -> None:
     state.logfire.warn('Hook: PreCompact ({trigger})', trigger=attrs.get(CLAUDE_COMPACT_TRIGGER, ''), **attrs)
 
 
-def _record_notification(state: _ConversationState, input_data: Any) -> None:
+def _record_notification(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Record a Notification hook event as an info log under the root span.
 
     ``claude.notification.message`` is NOT on SAFE_KEYS: CLI-emitted text
@@ -1556,8 +1544,6 @@ def _record_notification(state: _ConversationState, input_data: Any) -> None:
     that may evolve.
     """
     state.notification_count += 1
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     attrs: dict[str, Any] = {**_hook_session_id(input_data)}
     field_map: tuple[tuple[str, str], ...] = (
         ('message', CLAUDE_NOTIFICATION_MESSAGE),
@@ -1574,7 +1560,7 @@ def _record_notification(state: _ConversationState, input_data: Any) -> None:
     )
 
 
-def _record_permission_request(state: _ConversationState, input_data: Any) -> None:
+def _record_permission_request(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Record a PermissionRequest hook event as an info-level audit log.
 
     Captures ``agent_id`` / ``agent_type`` opportunistically when the
@@ -1585,8 +1571,6 @@ def _record_permission_request(state: _ConversationState, input_data: Any) -> No
     NOT on SAFE_KEYS, matching the ``claude.permission_denials`` precedent.
     """
     state.permission_request_count += 1
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     attrs: dict[str, Any] = {**_hook_session_id(input_data)}
     field_map: tuple[tuple[str, str], ...] = (
         ('tool_name', TOOL_NAME),
@@ -1684,8 +1668,7 @@ def _record_permission_result(
             # wire boundary in query.py).
             try:
                 attrs[CLAUDE_PERMISSION_RESULT_UPDATED_PERMISSIONS] = [
-                    p.to_dict() if hasattr(p, 'to_dict') else p
-                    for p in updated_permissions
+                    p.to_dict() if hasattr(p, 'to_dict') else p for p in updated_permissions
                 ]
             except Exception:  # pragma: no cover  # forward-compat: skip bad shape
                 pass
@@ -1698,8 +1681,10 @@ def _record_permission_result(
 
 
 def _wrap_can_use_tool(callback: Any) -> Any:
-    """Wrap a user-supplied ``can_use_tool`` callback so each invocation is
-    surfaced as a logfire log under the active ``invoke_agent`` span.
+    """Wrap a user-supplied ``can_use_tool`` callback for outcome tracing.
+
+    Each invocation is surfaced as a logfire log under the active
+    ``invoke_agent`` span.
 
     Idempotent: calling on an already-wrapped callable is a no-op (returns
     the same wrapper). Used by ``_inject_tracing_hooks`` to avoid double-
@@ -1749,7 +1734,7 @@ def _wrap_can_use_tool(callback: Any) -> Any:
 # ---------------------------------------------------------------------------
 
 
-def _record_subagent_start(state: _ConversationState, input_data: Any) -> None:
+def _record_subagent_start(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Open a ``subagent <agent_type>`` span and register it under ``agent_id``.
 
     Sibling of ``execute_tool Agent`` (the parent's view of the Task tool)
@@ -1763,8 +1748,6 @@ def _record_subagent_start(state: _ConversationState, input_data: Any) -> None:
     to group subagents by configured model and audit the system prompt
     that was in effect, without requiring a separate join.
     """
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     agent_id = input_data.get('agent_id')
     agent_type = input_data.get('agent_type') or ''
     if not agent_id:  # pragma: no cover  # shouldn't happen — both are required by SDK type
@@ -1827,6 +1810,7 @@ def _subagent_definition_attrs(options: Any, agent_type: str) -> dict[str, Any]:
     agents = getattr(options, 'agents', None)
     if not isinstance(agents, dict):
         return {}
+    agents = cast('dict[str, Any]', agents)
     definition = agents.get(agent_type)
     AgentDefinition = getattr(claude_agent_sdk, 'AgentDefinition', None)
     if AgentDefinition is None or not isinstance(definition, AgentDefinition):
@@ -1864,7 +1848,7 @@ def _subagent_definition_attrs(options: Any, agent_type: str) -> dict[str, Any]:
     return attrs
 
 
-def _record_subagent_stop(state: _ConversationState, input_data: Any) -> None:
+def _record_subagent_stop(state: _ConversationState, input_data: dict[str, Any]) -> None:
     """Close the matching ``subagent`` span (issue #3).
 
     The span envelope is the event record; no separate log is emitted.
@@ -1874,8 +1858,6 @@ def _record_subagent_stop(state: _ConversationState, input_data: Any) -> None:
     field defensively — same forward-compat pattern as the regular ``Stop``
     hook from #9.
     """
-    if not isinstance(input_data, dict):  # pragma: no cover
-        return
     agent_id = input_data.get('agent_id')
     if not agent_id:  # pragma: no cover
         return
@@ -1886,9 +1868,7 @@ def _record_subagent_stop(state: _ConversationState, input_data: Any) -> None:
     # ptui (rare — would imply SDK out-of-order delivery) degrade safely:
     # the lookup misses and the chat span parents under root.
     state.parent_tool_use_id_to_agent_id = {
-        ptui: aid
-        for ptui, aid in state.parent_tool_use_id_to_agent_id.items()
-        if aid != agent_id
+        ptui: aid for ptui, aid in state.parent_tool_use_id_to_agent_id.items() if aid != agent_id
     }
     last_assistant_message = input_data.get('last_assistant_message')
     transcript_path = input_data.get('agent_transcript_path')
@@ -1914,12 +1894,15 @@ def _record_task_started(state: _ConversationState, msg: Any) -> None:
     ``task_id == agent_id`` equality (verified in recon for sequential and
     interleaved-parallel dispatches).
     """
-    attrs = _msg_attrs(msg, (
-        ('task_id', CLAUDE_TASK_ID),
-        ('description', CLAUDE_TASK_DESCRIPTION),
-        ('task_type', CLAUDE_TASK_TYPE),
-        ('tool_use_id', TOOL_CALL_ID),
-    ))
+    attrs = _msg_attrs(
+        msg,
+        (
+            ('task_id', CLAUDE_TASK_ID),
+            ('description', CLAUDE_TASK_DESCRIPTION),
+            ('task_type', CLAUDE_TASK_TYPE),
+            ('tool_use_id', TOOL_CALL_ID),
+        ),
+    )
     tool_use_id = getattr(msg, 'tool_use_id', None)
     task_id = getattr(msg, 'task_id', None)
     if tool_use_id and task_id:
@@ -1934,13 +1917,16 @@ def _record_task_progress(state: _ConversationState, msg: Any) -> None:
     subagents (e.g. fast Task dispatches that finish in milliseconds) skip
     progress and go straight from start to notification.
     """
-    attrs = _msg_attrs(msg, (
-        ('task_id', CLAUDE_TASK_ID),
-        ('description', CLAUDE_TASK_DESCRIPTION),
-        ('last_tool_name', CLAUDE_TASK_LAST_TOOL_NAME),
-        ('tool_use_id', TOOL_CALL_ID),
-        ('usage', CLAUDE_TASK_USAGE),
-    ))
+    attrs = _msg_attrs(
+        msg,
+        (
+            ('task_id', CLAUDE_TASK_ID),
+            ('description', CLAUDE_TASK_DESCRIPTION),
+            ('last_tool_name', CLAUDE_TASK_LAST_TOOL_NAME),
+            ('tool_use_id', TOOL_CALL_ID),
+            ('usage', CLAUDE_TASK_USAGE),
+        ),
+    )
     state.logfire.info('Task progress', **attrs)
 
 
@@ -1954,14 +1940,17 @@ def _record_task_notification(state: _ConversationState, msg: Any) -> None:
     operators can filter by ``claude.task.status`` for failure dashboards.
     """
     status = getattr(msg, 'status', None)
-    attrs = _msg_attrs(msg, (
-        ('task_id', CLAUDE_TASK_ID),
-        ('status', CLAUDE_TASK_STATUS),
-        ('summary', CLAUDE_TASK_SUMMARY),
-        ('output_file', CLAUDE_TASK_OUTPUT_FILE),
-        ('tool_use_id', TOOL_CALL_ID),
-        ('usage', CLAUDE_TASK_USAGE),
-    ))
+    attrs = _msg_attrs(
+        msg,
+        (
+            ('task_id', CLAUDE_TASK_ID),
+            ('status', CLAUDE_TASK_STATUS),
+            ('summary', CLAUDE_TASK_SUMMARY),
+            ('output_file', CLAUDE_TASK_OUTPUT_FILE),
+            ('tool_use_id', TOOL_CALL_ID),
+            ('usage', CLAUDE_TASK_USAGE),
+        ),
+    )
 
     log = state.logfire.info
     if status == 'failed':
@@ -1972,18 +1961,20 @@ def _record_task_notification(state: _ConversationState, msg: Any) -> None:
 
 
 def _msg_session_id(msg: Any) -> dict[str, Any]:
-    """Extract ``session_id`` from a Task* message dataclass under the OTel
-    semconv ``gen_ai.conversation.id`` key. Returns ``{}`` when absent so
-    callers can splat unconditionally.
+    """Extract ``session_id`` from a Task* message dataclass.
+
+    Mapped under the OTel semconv ``gen_ai.conversation.id`` key. Returns
+    ``{}`` when absent so callers can splat unconditionally.
     """
     sid = getattr(msg, 'session_id', None)
     return {CONVERSATION_ID: sid} if sid else {}
 
 
 def _msg_attrs(msg: Any, field_map: tuple[tuple[str, str], ...]) -> dict[str, Any]:
-    """Build a Task* log attrs dict: session id seed plus every mapped field
-    that's set on ``msg`` (``is not None`` test so falsy-but-present values
-    like ``0`` survive).
+    """Build a Task* log attrs dict.
+
+    Session id seed plus every mapped field that's set on ``msg``
+    (``is not None`` test so falsy-but-present values like ``0`` survive).
     """
     attrs = _msg_session_id(msg)
     for sdk_field, attr_name in field_map:

--- a/tests/otel_integrations/test_claude_agent_sdk.py
+++ b/tests/otel_integrations/test_claude_agent_sdk.py
@@ -20,6 +20,7 @@ import stat
 from contextlib import suppress
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock
 
 import pytest
@@ -43,7 +44,7 @@ from claude_agent_sdk import (
     UserMessage,
 )
 from claude_agent_sdk._errors import CLINotFoundError, ProcessError
-from claude_agent_sdk.types import HookContext
+from claude_agent_sdk.types import HookContext, HookEvent
 from dirty_equals import IsStr
 from inline_snapshot import snapshot
 
@@ -680,7 +681,7 @@ def test_server_tool_result_persists_under_assistant_role_in_history() -> None:
 
         # After close, history should carry the assistant turn with both the
         # tool_call and the tool_call_response parts under role='assistant'.
-        history = state._history  # pyright: ignore[reportPrivateUsage]
+        history = state._history
         assert len(history) == 1
         turn = history[0]
         assert turn['role'] == 'assistant'
@@ -1021,7 +1022,7 @@ def test_inject_hooks_none_hooks() -> None:
     options = ClaudeAgentOptions(hooks=None)
     _inject_tracing_hooks(options)
     assert options.hooks is not None
-    expected_events = {
+    expected_events: set[HookEvent] = {
         'PreToolUse',
         'PostToolUse',
         'PostToolUseFailure',
@@ -1060,8 +1061,13 @@ def test_inject_hooks_with_existing_events() -> None:
     # New non-tool-lifecycle events are added too, even though Opts didn't
     # declare them.
     for event in (
-        'UserPromptSubmit', 'Stop', 'PreCompact', 'Notification',
-        'PermissionRequest', 'SubagentStart', 'SubagentStop',
+        'UserPromptSubmit',
+        'Stop',
+        'PreCompact',
+        'Notification',
+        'PermissionRequest',
+        'SubagentStart',
+        'SubagentStop',
     ):
         assert event in options.hooks
         assert len(options.hooks[event]) == 1
@@ -1547,7 +1553,7 @@ async def test_record_permission_result_deny_ends_open_execute_tool_span_promptl
         # Mimic ``pre_tool_use_hook`` having opened the execute_tool span
         # AND populated the diff snapshot — both should be cleaned up.
         tool_span = logfire_instance.span('execute_tool WebFetch')
-        tool_span._start()  # type: ignore[attr-defined]
+        tool_span._start()
         state.active_tool_spans['t3'] = tool_span
         state.original_tool_inputs['t3'] = {'url': 'https://example.com/'}
         _record_permission_result(
@@ -1561,8 +1567,8 @@ async def test_record_permission_result_deny_ends_open_execute_tool_span_promptl
         assert 't3' not in state.original_tool_inputs
         # Span end was triggered by the helper, not by ``state.close()``.
         # ``_end`` is idempotent so a later ``state.close()`` is harmless.
-        assert tool_span._span is not None  # type: ignore[attr-defined]
-        assert tool_span._span.end_time is not None  # type: ignore[attr-defined]
+        assert tool_span._span is not None
+        assert tool_span._span.end_time is not None
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     tool = next(s for s in spans if s['name'] == 'execute_tool WebFetch')
@@ -1768,7 +1774,7 @@ def _make_dummy_client() -> ClaudeSDKClient:
     client = ClaudeSDKClient(options=ClaudeAgentOptions())
     # Bypass ``connect`` — populate ``_query`` directly so the control
     # methods' "Not connected" guards pass.
-    client._query = _StubQuery()  # type: ignore[assignment]
+    client._query = _StubQuery()
     client._transport = Mock()
     return client
 
@@ -1920,7 +1926,7 @@ async def test_set_permission_mode_captures_mode(exporter: TestExporter) -> None
     ``CLAUDE_PERMISSION_MODE`` constant from the options-side capture
     in #8."""
     client = _make_dummy_client()
-    await client.set_permission_mode('acceptEdits')  # type: ignore[arg-type]
+    await client.set_permission_mode('acceptEdits')
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     s = next(s for s in spans if s['name'] == 'set_permission_mode')
@@ -2212,15 +2218,15 @@ async def test_tool_parent_otel_span_picks_subagent_when_agent_id_present(export
         # Subagent context — should return subagent's OTel span.
         sub_otel = _tool_parent_otel_span(state, {'agent_id': 'agent_A', 'tool_name': 'Bash'})
         assert sub_otel is not None
-        assert sub_otel is state.subagent_spans['agent_A']._span  # type: ignore[attr-defined]
+        assert sub_otel is state.subagent_spans['agent_A']._span
 
         # No agent_id — main thread; should return root.
         root_otel = _tool_parent_otel_span(state, {'tool_name': 'Bash'})
-        assert root_otel is state.root_span._span  # type: ignore[attr-defined]
+        assert root_otel is state.root_span._span
 
         # agent_id present but no matching subagent span (defensive) → root.
         unknown = _tool_parent_otel_span(state, {'agent_id': 'unknown_agent', 'tool_name': 'Bash'})
-        assert unknown is state.root_span._span  # type: ignore[attr-defined]
+        assert unknown is state.root_span._span
 
         _record_subagent_stop(state, {'agent_id': 'agent_A', 'agent_type': 'helper'})
 
@@ -2348,28 +2354,52 @@ async def test_three_parallel_subagents_each_tool_lands_under_correct_span(expor
             # Interleaved tool calls — each carries its own agent_id.
             await pre_tool_use_hook(
                 {'tool_name': 'Read', 'tool_input': {}, 'tool_use_id': 'tu_A1', 'agent_id': 'A_id'},
-                'tu_A1', ctx,
+                'tu_A1',
+                ctx,
             )
             await pre_tool_use_hook(
                 {'tool_name': 'Bash', 'tool_input': {}, 'tool_use_id': 'tu_C1', 'agent_id': 'C_id'},
-                'tu_C1', ctx,
+                'tu_C1',
+                ctx,
             )
             await pre_tool_use_hook(
                 {'tool_name': 'Grep', 'tool_input': {}, 'tool_use_id': 'tu_B1', 'agent_id': 'B_id'},
-                'tu_B1', ctx,
+                'tu_B1',
+                ctx,
             )
             # Posts in different order from pre.
             await post_tool_use_hook(
-                {'tool_name': 'Bash', 'tool_input': {}, 'tool_response': 'x', 'tool_use_id': 'tu_C1', 'agent_id': 'C_id'},
-                'tu_C1', ctx,
+                {
+                    'tool_name': 'Bash',
+                    'tool_input': {},
+                    'tool_response': 'x',
+                    'tool_use_id': 'tu_C1',
+                    'agent_id': 'C_id',
+                },
+                'tu_C1',
+                ctx,
             )
             await post_tool_use_hook(
-                {'tool_name': 'Read', 'tool_input': {}, 'tool_response': 'x', 'tool_use_id': 'tu_A1', 'agent_id': 'A_id'},
-                'tu_A1', ctx,
+                {
+                    'tool_name': 'Read',
+                    'tool_input': {},
+                    'tool_response': 'x',
+                    'tool_use_id': 'tu_A1',
+                    'agent_id': 'A_id',
+                },
+                'tu_A1',
+                ctx,
             )
             await post_tool_use_hook(
-                {'tool_name': 'Grep', 'tool_input': {}, 'tool_response': 'x', 'tool_use_id': 'tu_B1', 'agent_id': 'B_id'},
-                'tu_B1', ctx,
+                {
+                    'tool_name': 'Grep',
+                    'tool_input': {},
+                    'tool_response': 'x',
+                    'tool_use_id': 'tu_B1',
+                    'agent_id': 'B_id',
+                },
+                'tu_B1',
+                ctx,
             )
 
             # Stops in different order from starts (B finishes first, then A, then C).
@@ -2502,7 +2532,7 @@ async def test_three_parallel_subagents_chat_spans_attribute_correctly(exporter:
         annotated_agent_id = c['attributes']['claude.in_subagent.agent_id']
         assert c['parent']['span_id'] == by_agent_id[annotated_agent_id]['context']['span_id'], (
             f'chat span annotated with agent_id={annotated_agent_id} parented under '
-            f"span_id={c['parent']['span_id']}, expected {by_agent_id[annotated_agent_id]['context']['span_id']}"
+            f'span_id={c["parent"]["span_id"]}, expected {by_agent_id[annotated_agent_id]["context"]["span_id"]}'
         )
 
 
@@ -2602,7 +2632,9 @@ def test_subagent_stop_clears_parent_tool_use_id_to_agent_id_entries() -> None:
         _record_task_started(state, _task_started_msg(task_id='B_id', tool_use_id='tu_B1'))
 
         assert state.parent_tool_use_id_to_agent_id == {
-            'tu_A1': 'A_id', 'tu_A2': 'A_id', 'tu_B1': 'B_id',
+            'tu_A1': 'A_id',
+            'tu_A2': 'A_id',
+            'tu_B1': 'B_id',
         }
 
         _record_subagent_stop(state, {'agent_id': 'A_id', 'agent_type': 'reviewer'})
@@ -3860,7 +3892,7 @@ async def test_rate_limit_rejected_sets_error_level(exporter: TestExporter) -> N
             ),
             session_id='sess-abc',
         )
-        _record_rate_limit_event(logfire_instance, root, msg)
+        _record_rate_limit_event(logfire_instance, root, msg)  # pyright: ignore[reportArgumentType]
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     log_spans = [s for s in spans if s['name'] == 'rate_limit {status}']
@@ -3880,7 +3912,7 @@ async def test_mirror_error_without_key(exporter: TestExporter) -> None:
     """MirrorErrorMessage with key=None (not every mirror error has one)."""
     logfire_instance = logfire.DEFAULT_LOGFIRE_INSTANCE.with_settings(custom_scope_suffix='claude_agent_sdk')
     with logfire_instance.span('invoke_agent'):
-        _record_mirror_error(logfire_instance, SimpleNamespace(error='oh no', key=None))
+        _record_mirror_error(logfire_instance, SimpleNamespace(error='oh no', key=None))  # pyright: ignore[reportArgumentType]
 
     spans = exporter.exported_spans_as_dict(parse_json_attributes=True)
     mirror = next(s for s in spans if s['name'] == 'mirror store error: {error}')


### PR DESCRIPTION
## Summary

Brings the claude_agent_sdk integration in line with what upstream contribution gates require. \`make format\` / \`make lint\` / \`make typecheck\` all pass; the 98 claude_agent_sdk tests stay green; no behavior change.

This is the sibling cleanup to issues #2-#26 — those PRs all merged because the fork's local CI didn't run \`pyright\` and pytest doesn't run \`ruff\`. Upstream's CI does both, so we'd be rejected on the first push.

## What changed

**Production (\`logfire/_internal/integrations/claude_agent_sdk.py\`):**

- \`input_data: Any\` → \`input_data: dict[str, Any]\` on hook helpers. The SDK's BaseHookInput is structurally a \`dict[str, Any]\` TypedDict; pyright now narrows \`.get(...)\` properly and the cascade of *"Type of X is partially unknown"* disappears.
- Drop the \`if not isinstance(input_data, dict): return\` defensive guards on hook helpers — redundant under the new type, pyright flagged them. Runtime safety delegated to the SDK contract.
- \`cast(..., dict[str, Any])\` after \`isinstance(_, dict)\` for the non-helper paths that still receive \`Any\`-typed attributes (\`options.agents\`, \`MirrorErrorMessage.key\`, \`tool_input\`).
- Six D205 docstring fixes (blank line between summary and description) on \`_inject_tracing_hooks\`, \`handle_user_message\`, \`_hook_session_id\`, \`_wrap_can_use_tool\`, \`_msg_session_id\`, \`_msg_attrs\`.
- Move the \`getattr\` block for optional SDK message types after the semconv / opentelemetry imports so E402 is satisfied.
- Drop the dead \`patched_receive_messages = None\` else branch — pyright flagged the assignment as type-incompatible and the variable is never read after the conditional.

**Tests (\`tests/otel_integrations/test_claude_agent_sdk.py\`):**

- Add missing \`Any\` and \`HookEvent\` imports (pre-existing F821s hidden because pytest doesn't run ruff).
- Type \`expected_events\` as \`set[HookEvent]\` so \`options.hooks[event]\` resolves to the typed Literal key.
- Drop nine unnecessary \`# type: ignore\` / \`# pyright: ignore\` comments — \`reportPrivateUsage=false\` at the top of the file already covers them.
- Annotate the two SimpleNamespace fakes that intentionally substitute for SDK dataclasses with a targeted \`# pyright: ignore[reportArgumentType]\`.

## Verification

| Gate | Before | After |
|---|---|---|
| \`make format\` | 24 errors | 0 |
| \`make lint\` | failing | pass |
| \`make typecheck\` | 58 errors | 0 |
| claude_agent_sdk tests | 98/98 | 98/98 |
| Pre-existing infra failures (celery/mysql/redis/config) | 28 | 28 (unchanged) |

## Test plan
- [x] \`make format\` clean.
- [x] \`make lint\` clean.
- [x] \`make typecheck\` clean.
- [x] \`pytest tests/otel_integrations/test_claude_agent_sdk.py\` 98/98.
- [x] Pre-commit hooks (\`ruff\`, \`ruff format\`, \`pyright\`) all green on the commit.